### PR TITLE
削除と更新のAPI定義

### DIFF
--- a/backend/src/muscle/muscle.controller.ts
+++ b/backend/src/muscle/muscle.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  Patch,
+} from '@nestjs/common';
 import { MuscleService } from './muscle.service';
 import { CreateMuscleDto } from './dto/create-muscle.dto';
 
@@ -19,6 +27,14 @@ export class MuscleController {
   @Post()
   async create(@Body() createMuscleDto: CreateMuscleDto) {
     return await this.muscleService.create(createMuscleDto);
+  }
+
+  @Patch('id=:id')
+  async update(
+    @Param('id') id: number,
+    @Body() createMuscleDto: CreateMuscleDto,
+  ) {
+    return await this.muscleService.update(+id, createMuscleDto);
   }
 
   @Delete('id=:id')

--- a/backend/src/muscle/muscle.controller.ts
+++ b/backend/src/muscle/muscle.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common';
 import { MuscleService } from './muscle.service';
 import { CreateMuscleDto } from './dto/create-muscle.dto';
 
@@ -19,5 +19,10 @@ export class MuscleController {
   @Post()
   async create(@Body() createMuscleDto: CreateMuscleDto) {
     return await this.muscleService.create(createMuscleDto);
+  }
+
+  @Delete()
+  async delete(@Param('category_id') categoryId: number) {
+    return await this.muscleService.delete(categoryId);
   }
 }

--- a/backend/src/muscle/muscle.controller.ts
+++ b/backend/src/muscle/muscle.controller.ts
@@ -21,8 +21,8 @@ export class MuscleController {
     return await this.muscleService.create(createMuscleDto);
   }
 
-  @Delete()
-  async delete(@Param('category_id') categoryId: number) {
-    return await this.muscleService.delete(categoryId);
+  @Delete('id=:id')
+  async delete(@Param('id') id: number) {
+    return await this.muscleService.delete(+id);
   }
 }

--- a/backend/src/muscle/muscle.service.ts
+++ b/backend/src/muscle/muscle.service.ts
@@ -48,6 +48,17 @@ export class MuscleService {
     return training;
   }
 
+  async update(id: number, createMuscleDto: CreateMuscleDto) {
+    const updateResult = await this.prisma.$executeRaw`
+      UPDATE muscle_training SET
+      category_id = ${createMuscleDto.category_id},
+      date = ${new Date(createMuscleDto.date)},
+      count = ${createMuscleDto.count}
+      WHERE id = ${id};;
+    `;
+    return updateResult;
+  }
+
   async delete(id: number) {
     await this.prisma.$executeRaw`
     DELETE FROM muscle_training WHERE id = ${id};

--- a/backend/src/muscle/muscle.service.ts
+++ b/backend/src/muscle/muscle.service.ts
@@ -48,9 +48,9 @@ export class MuscleService {
     return training;
   }
 
-  async delete(categoryId: number) {
-    const result = await this.prisma.$executeRaw`
-    DELETE FROM muscle_training WHERE category_id = ${categoryId};
+  async delete(id: number) {
+    await this.prisma.$executeRaw`
+    DELETE FROM muscle_training WHERE id = ${id};
     `;
     return;
   }

--- a/backend/src/muscle/muscle.service.ts
+++ b/backend/src/muscle/muscle.service.ts
@@ -47,4 +47,11 @@ export class MuscleService {
         `;
     return training;
   }
+
+  async delete(categoryId: number) {
+    const result = await this.prisma.$executeRaw`
+    DELETE FROM muscle_training WHERE category_id = ${categoryId};
+    `;
+    return;
+  }
 }

--- a/backend/src/muscle/muscle.service.ts
+++ b/backend/src/muscle/muscle.service.ts
@@ -17,6 +17,7 @@ export class MuscleService {
     LEFT JOIN
       mst_muscle_category as mmc
     ON mt.category_id = mmc.id
+    ORDER BY mt.date;
     `;
     return result;
   }
@@ -31,7 +32,8 @@ export class MuscleService {
     FROM muscle_training as mt
     INNER JOIN mst_muscle_category as mmt
     ON mmt.id = mt.category_id
-    WHERE mt.category_id = ${+categoryId};
+    WHERE mt.category_id = ${+categoryId}
+    ORDER BY mt.date;
     `;
     return result;
   }
@@ -54,7 +56,7 @@ export class MuscleService {
       category_id = ${createMuscleDto.category_id},
       date = ${new Date(createMuscleDto.date)},
       count = ${createMuscleDto.count}
-      WHERE id = ${id};;
+      WHERE id = ${id};
     `;
     return updateResult;
   }


### PR DESCRIPTION
# Why
- 取得一覧のレコードの削除と更新機能を実装するため

# What
- [ ]  deleteメソッドを定義
- [ ]  deleteデコレータを定義
- [ ]  updateメソッドを定義
- [ ]  patchデコレータを定義
- [ ]  一覧取得処理の際に、日付で並び替える処理を追加