### PR TITLE
フロントの編集機能を実装

### DIFF
--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 type Props = {
   onClick: (formDate: FormData) => void;
   actionName: string;

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -1,0 +1,29 @@
+type Props = {
+  onClick: (formDate: FormData) => void;
+  actionName: string;
+};
+
+const InputForm = (props: Props) => {
+  return (
+    <div>
+      <h1>{props.actionName}ぺージ</h1>
+      <form action={props.onClick}>
+        <div>
+          <select name="category_id">
+            <option value="1">腹筋</option>
+            <option value="2">腕立て</option>
+            <option value="3">背筋</option>
+          </select>
+        </div>
+        <div>
+          <input type="date" name="date" />
+        </div>
+        <div>
+          <input type="number" name="count" />
+        </div>
+        <button type="submit">{props.actionName}</button>
+      </form>
+    </div>
+  );
+};
+export default InputForm;

--- a/frontend/app/pages/components/Title.tsx
+++ b/frontend/app/pages/components/Title.tsx
@@ -1,8 +1,0 @@
-const Title = () => {
-  return {
-    title: "筋トレ管理アプリ",
-    description: "description",
-    content: "筋トレ",
-  };
-};
-export default Title;

--- a/frontend/app/pages/components/Title.tsx
+++ b/frontend/app/pages/components/Title.tsx
@@ -1,0 +1,8 @@
+const Title = () => {
+  return {
+    title: "筋トレ管理アプリ",
+    description: "description",
+    content: "筋トレ",
+  };
+};
+export default Title;

--- a/frontend/app/pages/components/TrainingList.tsx
+++ b/frontend/app/pages/components/TrainingList.tsx
@@ -41,6 +41,7 @@ const TrainingList = ({
                 <th className="training-record-cell">{formattedDate}</th>
                 <th className="training-record-cell">{c.count}</th>
                 <th className="training-record-cell">
+                  <Button onClick={() => {}} buttonName="編集" />
                   <Button
                     onClick={() => TrainingListDelete(c.id)}
                     buttonName="削除"

--- a/frontend/app/pages/components/TrainingList.tsx
+++ b/frontend/app/pages/components/TrainingList.tsx
@@ -1,5 +1,6 @@
 import type { TrainingRecord } from "~/type/training_record_type";
 import Button from "./Button";
+import { useNavigate } from "react-router";
 
 type TrainingRecordProps = {
   trainingRecord: TrainingRecord[];
@@ -18,6 +19,10 @@ const TrainingList = ({
       alert("削除が完了しました。");
       getTrainingRecord();
     }
+  };
+  const navigate = useNavigate();
+  const navigateToUpdatePage = (id: number) => {
+    navigate(`/update/${id}`);
   };
   return (
     <div>
@@ -41,7 +46,10 @@ const TrainingList = ({
                 <th className="training-record-cell">{formattedDate}</th>
                 <th className="training-record-cell">{c.count}</th>
                 <th className="training-record-cell">
-                  <Button onClick={() => {}} buttonName="編集" />
+                  <Button
+                    onClick={() => navigateToUpdatePage(c.id)}
+                    buttonName="編集"
+                  />
                   <Button
                     onClick={() => TrainingListDelete(c.id)}
                     buttonName="削除"

--- a/frontend/app/pages/components/UpdatePage.tsx
+++ b/frontend/app/pages/components/UpdatePage.tsx
@@ -1,0 +1,55 @@
+import Button from "~/pages/components/Button";
+import InputForm from "./InputForm";
+import { useNavigate, useParams } from "react-router";
+
+const UpdatePage = () => {
+  // URL から id を取得
+  const { id } = useParams<{ id: string }>();
+  const idNumber = Number(id);
+
+  const updateTraining = async (formData: FormData) => {
+    const categoryId = formData.get("category_id");
+    const date = formData.get("date");
+    const count = formData.get("count");
+    if (categoryId && date && count) {
+      await fetch(`http://localhost:3000/muscle/id=${idNumber}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          category_id: +categoryId!,
+          date: date,
+          count: +count!,
+        }),
+      });
+      alert("更新が完了しました。");
+      backTopPage();
+    } else {
+      const alertMessage: string[] = [];
+      if (!categoryId) {
+        alertMessage.push("トレーニングを選択してください");
+      }
+      if (!date) {
+        alertMessage.push("実施日を選択してください");
+      }
+      if (!count) {
+        alertMessage.push("回数を入力してください");
+      }
+      alert(alertMessage.join("\n"));
+    }
+  };
+
+  const navigate = useNavigate();
+  const backTopPage = () => {
+    navigate("/");
+  };
+
+  return (
+    <div>
+      <InputForm onClick={updateTraining} actionName="更新" />
+      <Button onClick={backTopPage} buttonName="戻る" />
+    </div>
+  );
+};
+export default UpdatePage;

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -3,4 +3,5 @@ import { type RouteConfig, index, route } from "@react-router/dev/routes";
 export default [
   route("/", "routes/home.tsx"),
   route("create", "routes/create.tsx"),
+  route("update/:id", "routes/update.tsx"),
 ] satisfies RouteConfig;

--- a/frontend/app/routes/create.tsx
+++ b/frontend/app/routes/create.tsx
@@ -1,12 +1,11 @@
 import Button from "~/pages/components/Button";
 import type { Route } from "../+types/root";
 import { useNavigate } from "react-router";
+import Title from "~/pages/components/title";
 
 export function meta({}: Route.MetaArgs) {
-  return [
-    { title: "筋トレ管理アプリ" },
-    { name: "description", content: "筋トレ登録" },
-  ];
+  const titleProps = Title();
+  return [titleProps];
 }
 // 1 podtapiにデータを送る関数を定義する
 // 2 console.logで入力した値が取れるか確認

--- a/frontend/app/routes/create.tsx
+++ b/frontend/app/routes/create.tsx
@@ -1,11 +1,16 @@
 import Button from "~/pages/components/Button";
 import type { Route } from "../+types/root";
 import { useNavigate } from "react-router";
-import Title from "~/pages/components/title";
+import Title from "~/utils/Title";
 
 export function meta({}: Route.MetaArgs) {
-  const titleProps = Title();
-  return [titleProps];
+  return [
+    {
+      title: Title.title,
+      description: Title.description,
+      content: Title.content,
+    },
+  ];
 }
 // 1 podtapiにデータを送る関数を定義する
 // 2 console.logで入力した値が取れるか確認

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,10 +1,15 @@
 import { Top } from "~/pages/Top";
-import Title from "~/pages/components/title";
 import type { Route } from "./+types/home";
+import Title from "~/utils/Title";
 
 export function meta({}: Route.MetaArgs) {
-  const titleProps = Title();
-  return [titleProps];
+  return [
+    {
+      title: Title.title,
+      description: Title.description,
+      content: Title.content,
+    },
+  ];
 }
 
 export default function Home() {

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,11 +1,10 @@
 import { Top } from "~/pages/Top";
+import Title from "~/pages/components/title";
 import type { Route } from "./+types/home";
 
 export function meta({}: Route.MetaArgs) {
-  return [
-    { title: "筋トレ管理アプリ" },
-    { name: "description", content: "筋トレ管理" },
-  ];
+  const titleProps = Title();
+  return [titleProps];
 }
 
 export default function Home() {

--- a/frontend/app/routes/update.tsx
+++ b/frontend/app/routes/update.tsx
@@ -1,0 +1,12 @@
+import type { Route } from "../+types/root";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "筋トレ管理アプリ" },
+    { name: "description", content: "筋トレ記録更新" },
+  ];
+}
+
+export default function Create() {
+  return <h1>テスト</h1>;
+}

--- a/frontend/app/routes/update.tsx
+++ b/frontend/app/routes/update.tsx
@@ -1,12 +1,77 @@
+import Button from "~/pages/components/Button";
 import type { Route } from "../+types/root";
+import { useNavigate, useParams } from "react-router";
 
 export function meta({}: Route.MetaArgs) {
   return [
     { title: "筋トレ管理アプリ" },
-    { name: "description", content: "筋トレ記録更新" },
+    { name: "description", content: "筋トレ登録" },
   ];
 }
 
-export default function Create() {
-  return <h1>テスト</h1>;
+export default function Update() {
+  // URL から id を取得
+  const { id } = useParams<{ id: string }>();
+  const idNumber = Number(id);
+
+  const updateTraining = async (formData: FormData) => {
+    const categoryId = formData.get("category_id");
+    const date = formData.get("date");
+    const count = formData.get("count");
+    if (categoryId && date && count) {
+      await fetch(`http://localhost:3000/muscle/id=${idNumber}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          category_id: +categoryId!,
+          date: date,
+          count: +count!,
+        }),
+      });
+      alert("更新が完了しました。");
+      backTopPage();
+    } else {
+      const alertMessage: string[] = [];
+      if (!categoryId) {
+        alertMessage.push("トレーニングを選択してください");
+      }
+      if (!date) {
+        alertMessage.push("実施日を選択してください");
+      }
+      if (!count) {
+        alertMessage.push("回数を入力してください");
+      }
+      alert(alertMessage.join("\n"));
+    }
+  };
+
+  const navigate = useNavigate();
+  const backTopPage = () => {
+    navigate("/");
+  };
+
+  return (
+    <div>
+      <h1>更新ぺージ</h1>
+      <form action={updateTraining}>
+        <div>
+          <select name="category_id">
+            <option value="1">腹筋</option>
+            <option value="2">腕立て</option>
+            <option value="3">背筋</option>
+          </select>
+        </div>
+        <div>
+          <input type="date" name="date" />
+        </div>
+        <div>
+          <input type="number" name="count" />
+        </div>
+        <button type="submit">更新</button>
+      </form>
+      <Button onClick={backTopPage} buttonName="戻る" />
+    </div>
+  );
 }

--- a/frontend/app/routes/update.tsx
+++ b/frontend/app/routes/update.tsx
@@ -1,11 +1,10 @@
+import Title from "~/pages/components/title";
 import type { Route } from "../+types/root";
 import UpdatePage from "~/pages/components/UpdatePage";
 
 export function meta({}: Route.MetaArgs) {
-  return [
-    { title: "筋トレ管理アプリ" },
-    { name: "description", content: "筋トレ登録" },
-  ];
+  const titleProps = Title();
+  return [titleProps];
 }
 
 export default function Update() {

--- a/frontend/app/routes/update.tsx
+++ b/frontend/app/routes/update.tsx
@@ -1,10 +1,15 @@
-import Title from "~/pages/components/title";
 import type { Route } from "../+types/root";
 import UpdatePage from "~/pages/components/UpdatePage";
+import Title from "~/utils/Title";
 
 export function meta({}: Route.MetaArgs) {
-  const titleProps = Title();
-  return [titleProps];
+  return [
+    {
+      title: Title.title,
+      description: Title.description,
+      content: Title.content,
+    },
+  ];
 }
 
 export default function Update() {

--- a/frontend/app/routes/update.tsx
+++ b/frontend/app/routes/update.tsx
@@ -1,6 +1,5 @@
-import Button from "~/pages/components/Button";
 import type { Route } from "../+types/root";
-import { useNavigate, useParams } from "react-router";
+import UpdatePage from "~/pages/components/UpdatePage";
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -10,68 +9,5 @@ export function meta({}: Route.MetaArgs) {
 }
 
 export default function Update() {
-  // URL から id を取得
-  const { id } = useParams<{ id: string }>();
-  const idNumber = Number(id);
-
-  const updateTraining = async (formData: FormData) => {
-    const categoryId = formData.get("category_id");
-    const date = formData.get("date");
-    const count = formData.get("count");
-    if (categoryId && date && count) {
-      await fetch(`http://localhost:3000/muscle/id=${idNumber}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          category_id: +categoryId!,
-          date: date,
-          count: +count!,
-        }),
-      });
-      alert("更新が完了しました。");
-      backTopPage();
-    } else {
-      const alertMessage: string[] = [];
-      if (!categoryId) {
-        alertMessage.push("トレーニングを選択してください");
-      }
-      if (!date) {
-        alertMessage.push("実施日を選択してください");
-      }
-      if (!count) {
-        alertMessage.push("回数を入力してください");
-      }
-      alert(alertMessage.join("\n"));
-    }
-  };
-
-  const navigate = useNavigate();
-  const backTopPage = () => {
-    navigate("/");
-  };
-
-  return (
-    <div>
-      <h1>更新ぺージ</h1>
-      <form action={updateTraining}>
-        <div>
-          <select name="category_id">
-            <option value="1">腹筋</option>
-            <option value="2">腕立て</option>
-            <option value="3">背筋</option>
-          </select>
-        </div>
-        <div>
-          <input type="date" name="date" />
-        </div>
-        <div>
-          <input type="number" name="count" />
-        </div>
-        <button type="submit">更新</button>
-      </form>
-      <Button onClick={backTopPage} buttonName="戻る" />
-    </div>
-  );
+  return <UpdatePage />;
 }

--- a/frontend/app/utils/Title.ts
+++ b/frontend/app/utils/Title.ts
@@ -1,0 +1,7 @@
+class Title {
+  static title = "筋トレ管理アプリ";
+  static description = "description";
+  static content = "筋トレ";
+}
+
+export default Title;


### PR DESCRIPTION
# Why
- 一覧取得結果に対する編集機能を実装

# What
- [ ] 一覧取得の列に編集ボタンを実装
- [ ] 編集画面を実装
- [ ] ルーティングを設定
- [ ] 編集ボタンをクリックした際に編集画面へ遷移する処理を実装
- [ ] 更新処理を実装 

# Other
- [ ] 編集画面に遷移した際に、idに紐づくcategory_id,date,countを取得し、画面表示することを今後の課題とする