### PR TITLE
更新ページの初期値設定

### DIFF
--- a/backend/src/muscle/muscle.service.ts
+++ b/backend/src/muscle/muscle.service.ts
@@ -13,11 +13,11 @@ export class MuscleService {
       mt.id,
       mt.date,
       mt.count,
-      mmc.name
+      mmt.name
     FROM muscle_training as mt
     LEFT JOIN
-      mst_muscle_category as mmc
-    ON mt.category_id = mmc.id
+      mst_muscle_category as mmt
+    ON mt.category_id = mmt.id
     ORDER BY mt.date;
     `;
     return result;
@@ -43,12 +43,10 @@ export class MuscleService {
     const result = await this.prisma.$queryRaw<TrainingData[]>`
     SELECT
       mt.id,
-      mmt.name,
+      mt.category_id,
       mt.date,
       mt.count
     FROM muscle_training as mt
-    INNER JOIN mst_muscle_category as mmt
-    ON mmt.id = mt.category_id
     WHERE mt.id = ${+id}
     `;
     return result[0];

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import TrainingList from "./components/TrainingList";
-import type { TrainingRecord } from "~/type/training_record_type";
 import Button from "./components/Button";
 import { useNavigate } from "react-router";
 import CategorySelectionPulldown from "./components/CategorySelectionPulldown";
+import type { TrainingRecord } from "~/type/training_record_type copy";
 
 export function Top() {
   // useNavigateを定義 useNavigateは

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -3,7 +3,7 @@ import TrainingList from "./components/TrainingList";
 import Button from "./components/Button";
 import { useNavigate } from "react-router";
 import CategorySelectionPulldown from "./components/CategorySelectionPulldown";
-import type { TrainingRecord } from "~/type/training_record_type copy";
+import type { TrainingRecord } from "~/type/training_record_type";
 
 export function Top() {
   // useNavigateを定義 useNavigateは

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -28,6 +28,14 @@ const InputForm = (props: Props) => {
     console.log("stateの値:", trainingRecord);
   }, [trainingRecord]);
 
+  const handleCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newCount = +e.target.value;
+    setTrainingRecord({
+      ...trainingRecord,
+      count: newCount,
+    });
+  };
+
   return (
     <div>
       <h1>{props.actionName}ぺージ</h1>
@@ -47,7 +55,7 @@ const InputForm = (props: Props) => {
             type="number"
             name="count"
             value={trainingRecord.count}
-            onChange={() => {}}
+            onChange={handleCountChange}
           />
         </div>
         <button type="submit">{props.actionName}</button>

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -1,9 +1,22 @@
+import { useEffect } from "react";
+import { useParams } from "react-router";
+
 type Props = {
   onClick: (formDate: FormData) => void;
   actionName: string;
 };
 
 const InputForm = (props: Props) => {
+  const { id } = useParams<{ id: string }>();
+
+  useEffect(() => {
+    (async () => {
+      const response = await fetch(`http://localhost:3000/muscle/id=${id}`);
+      const result = await response.json();
+      console.log(result);
+    })();
+  }, []);
+
   return (
     <div>
       <h1>{props.actionName}ぺージ</h1>

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -36,12 +36,24 @@ const InputForm = (props: Props) => {
     });
   };
 
+  const handleCategoryIdChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newCategoryId = +e.target.value;
+    setTrainingData({
+      ...trainingData,
+      category_id: newCategoryId,
+    });
+  };
+
   return (
     <div>
       <h1>{props.actionName}ぺージ</h1>
       <form action={props.onClick}>
         <div>
-          <select name="category_id">
+          <select
+            name="category_id"
+            value={trainingData.category_id}
+            onChange={handleCategoryIdChange}
+          >
             <option value="1">腹筋</option>
             <option value="2">腕立て</option>
             <option value="3">背筋</option>

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
-import type { TrainingRecord } from "~/type/training_record_type";
+import type { TrainingData } from "~/type/training_data_type";
 
 type Props = {
   onClick: (formDate: FormData) => void;
@@ -9,9 +9,9 @@ type Props = {
 
 const InputForm = (props: Props) => {
   const { id } = useParams<{ id: string }>();
-  const [trainingRecord, setTrainingRecord] = useState<TrainingRecord>({
+  const [trainingData, setTrainingData] = useState<TrainingData>({
     id: 0,
-    name: "",
+    category_id: 0,
     date: new Date(),
     count: 0,
   });
@@ -21,17 +21,17 @@ const InputForm = (props: Props) => {
       const response = await fetch(`http://localhost:3000/muscle/id=${id}`);
       const result = await response.json();
       console.log("api取得結果:", result);
-      setTrainingRecord({ ...result });
+      setTrainingData({ ...result });
     })();
   }, []);
   useEffect(() => {
-    console.log("stateの値:", trainingRecord);
-  }, [trainingRecord]);
+    console.log("stateの値:", trainingData);
+  }, [trainingData]);
 
   const handleCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newCount = +e.target.value;
-    setTrainingRecord({
-      ...trainingRecord,
+    setTrainingData({
+      ...trainingData,
       count: newCount,
     });
   };
@@ -54,7 +54,7 @@ const InputForm = (props: Props) => {
           <input
             type="number"
             name="count"
-            value={trainingRecord.count}
+            value={trainingData.count}
             onChange={handleCountChange}
           />
         </div>

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -43,7 +43,12 @@ const InputForm = (props: Props) => {
           <input type="date" name="date" />
         </div>
         <div>
-          <input type="number" name="count" />
+          <input
+            type="number"
+            name="count"
+            value={trainingRecord.count}
+            onChange={() => {}}
+          />
         </div>
         <button type="submit">{props.actionName}</button>
       </form>

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -21,26 +21,35 @@ const InputForm = (props: Props) => {
       const response = await fetch(`http://localhost:3000/muscle/id=${id}`);
       const result = await response.json();
       console.log("api取得結果:", result);
-      setTrainingData({ ...result });
+      setTrainingData({ ...result, date: new Date(result.date) });
     })();
   }, []);
   useEffect(() => {
     console.log("stateの値:", trainingData);
   }, [trainingData]);
 
-  const handleCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newCount = +e.target.value;
-    setTrainingData({
-      ...trainingData,
-      count: newCount,
-    });
-  };
-
   const handleCategoryIdChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newCategoryId = +e.target.value;
     setTrainingData({
       ...trainingData,
       category_id: newCategoryId,
+    });
+  };
+
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newDateStr = e.target.value;
+    const newDate = new Date(newDateStr);
+    setTrainingData({
+      ...trainingData,
+      date: newDate,
+    });
+  };
+
+  const handleCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newCount = +e.target.value;
+    setTrainingData({
+      ...trainingData,
+      count: newCount,
     });
   };
 
@@ -60,7 +69,12 @@ const InputForm = (props: Props) => {
           </select>
         </div>
         <div>
-          <input type="date" name="date" />
+          <input
+            type="date"
+            name="date"
+            value={trainingData.date.toISOString().split("T")[0]}
+            onChange={handleDateChange}
+          />
         </div>
         <div>
           <input

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router";
+import type { TrainingRecord } from "~/type/training_record_type";
 
 type Props = {
   onClick: (formDate: FormData) => void;
@@ -8,14 +9,24 @@ type Props = {
 
 const InputForm = (props: Props) => {
   const { id } = useParams<{ id: string }>();
+  const [trainingRecord, setTrainingRecord] = useState<TrainingRecord>({
+    id: 0,
+    name: "",
+    date: new Date(),
+    count: 0,
+  });
 
   useEffect(() => {
     (async () => {
       const response = await fetch(`http://localhost:3000/muscle/id=${id}`);
       const result = await response.json();
-      console.log(result);
+      console.log("api取得結果:", result);
+      setTrainingRecord({ ...result });
     })();
   }, []);
+  useEffect(() => {
+    console.log("stateの値:", trainingRecord);
+  }, [trainingRecord]);
 
   return (
     <div>

--- a/frontend/app/type/training_data_type.ts
+++ b/frontend/app/type/training_data_type.ts
@@ -1,6 +1,6 @@
 export type TrainingData = {
   id: number;
+  category_id: number;
   date: Date;
   count: number;
-  category_id: number;
 };


### PR DESCRIPTION
# Why
- 更新ページに遷移した際に、idに紐づくデータをセットする

# What
- [ ] 個別データ取得apiの結果をオブジェクトで取得し、フロントから呼び出す
- [ ] 個別データ取得apiで取得するプロパティをnameからcategoryに変更
- [ ] useStateでcategory_id,date,countの状態を管理