### PR TITLE
マスタの全取得APIを作成し、プルダウンに取得結果を表示する

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { MuscleModule } from './muscle/muscle.module';
 import { PrismaService } from './prisma.service';
+import { MstMuscleCategoryModule } from './mst-muscle-category/mst-muscle-category.module';
 
 @Module({
-  imports: [MuscleModule],
+  imports: [MuscleModule, MstMuscleCategoryModule],
   controllers: [AppController],
   providers: [AppService, PrismaService],
 })

--- a/backend/src/mst-muscle-category/dto/create-mst-muscle-category.dto.ts
+++ b/backend/src/mst-muscle-category/dto/create-mst-muscle-category.dto.ts
@@ -1,0 +1,1 @@
+export class CreateMstMuscleCategoryDto {}

--- a/backend/src/mst-muscle-category/dto/create-mst-muscle-category.dto.ts
+++ b/backend/src/mst-muscle-category/dto/create-mst-muscle-category.dto.ts
@@ -1,1 +1,0 @@
-export class CreateMstMuscleCategoryDto {}

--- a/backend/src/mst-muscle-category/mst-muscle-category.controller.spec.ts
+++ b/backend/src/mst-muscle-category/mst-muscle-category.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MstMuscleCategoryController } from './mst-muscle-category.controller';
+import { MstMuscleCategoryService } from './mst-muscle-category.service';
+
+describe('MstMuscleCategoryController', () => {
+  let controller: MstMuscleCategoryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MstMuscleCategoryController],
+      providers: [MstMuscleCategoryService],
+    }).compile();
+
+    controller = module.get<MstMuscleCategoryController>(MstMuscleCategoryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/mst-muscle-category/mst-muscle-category.controller.ts
+++ b/backend/src/mst-muscle-category/mst-muscle-category.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@nestjs/common';
+import { MstMuscleCategoryService } from './mst-muscle-category.service';
+
+@Controller('mst-muscle-category')
+export class MstMuscleCategoryController {
+  constructor(
+    private readonly mstMuscleCategoryService: MstMuscleCategoryService,
+  ) {}
+}

--- a/backend/src/mst-muscle-category/mst-muscle-category.controller.ts
+++ b/backend/src/mst-muscle-category/mst-muscle-category.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { MstMuscleCategoryService } from './mst-muscle-category.service';
 
 @Controller('mst-muscle-category')
@@ -6,4 +6,9 @@ export class MstMuscleCategoryController {
   constructor(
     private readonly mstMuscleCategoryService: MstMuscleCategoryService,
   ) {}
+
+  @Get()
+  async findAll() {
+    return await this.mstMuscleCategoryService.findAll();
+  }
 }

--- a/backend/src/mst-muscle-category/mst-muscle-category.module.ts
+++ b/backend/src/mst-muscle-category/mst-muscle-category.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MstMuscleCategoryService } from './mst-muscle-category.service';
+import { MstMuscleCategoryController } from './mst-muscle-category.controller';
+import { PrismaService } from 'src/prisma.service';
+
+@Module({
+  controllers: [MstMuscleCategoryController],
+  providers: [MstMuscleCategoryService, PrismaService],
+})
+export class MstMuscleCategoryModule {}

--- a/backend/src/mst-muscle-category/mst-muscle-category.service.spec.ts
+++ b/backend/src/mst-muscle-category/mst-muscle-category.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MstMuscleCategoryService } from './mst-muscle-category.service';
+
+describe('MstMuscleCategoryService', () => {
+  let service: MstMuscleCategoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MstMuscleCategoryService],
+    }).compile();
+
+    service = module.get<MstMuscleCategoryService>(MstMuscleCategoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/mst-muscle-category/mst-muscle-category.service.ts
+++ b/backend/src/mst-muscle-category/mst-muscle-category.service.ts
@@ -1,4 +1,18 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
 
 @Injectable()
-export class MstMuscleCategoryService {}
+export class MstMuscleCategoryService {
+  constructor(private prisma: PrismaService) {}
+
+  async findAll() {
+    const result = await this.prisma.$queryRaw`
+      SELECT
+        mmc.id,
+        mmc.name
+      FROM mst_muscle_category as mmc
+      ORDER BY mmc.id;
+      `;
+    return result;
+  }
+}

--- a/backend/src/mst-muscle-category/mst-muscle-category.service.ts
+++ b/backend/src/mst-muscle-category/mst-muscle-category.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MstMuscleCategoryService {}

--- a/backend/src/mst-muscle-category/mst-muscle-category.service.ts
+++ b/backend/src/mst-muscle-category/mst-muscle-category.service.ts
@@ -11,7 +11,7 @@ export class MstMuscleCategoryService {
         mmc.id,
         mmc.name
       FROM mst_muscle_category as mmc
-      ORDER BY mmc.id;
+      ORDER BY mmc.id ASC;
       `;
     return result;
   }

--- a/frontend/app/pages/components/CategorySelectionPulldown.tsx
+++ b/frontend/app/pages/components/CategorySelectionPulldown.tsx
@@ -1,7 +1,3 @@
-/*
-課題1. setFilerValの型をanyから修正する
-課題2. プルダウンをハードコーディングからmst_muscle_categoryから取得できるようにする
-*/
 import React, { useEffect, useState } from "react";
 type CategorySelectionPulldownProps = {
   setFilterVal: React.Dispatch<React.SetStateAction<number>>;

--- a/frontend/app/pages/components/CategorySelectionPulldown.tsx
+++ b/frontend/app/pages/components/CategorySelectionPulldown.tsx
@@ -18,19 +18,22 @@ const CategorySelectionPulldown = ({
   const [trainingName, setTrainingName] = useState<MstMuscleCategory[]>([]);
   const getMstMuscleCategory = async () => {
     const response = await fetch(`http://localhost:3000/mst-muscle-category`);
-    const result = response.json();
+    const result = await response.json();
+    setTrainingName(result);
     console.log("マスタ取得結果", result);
   };
 
   useEffect(() => {
     getMstMuscleCategory();
-  });
+  }, []);
 
   return (
     <select name="category_id" onChange={(e) => setFilterVal(+e.target.value)}>
-      <option value="1">腹筋</option>
-      <option value="2">腕立て</option>
-      <option value="3">背筋</option>
+      {trainingName.map((category) => (
+        <option key={category.id} value={category.id}>
+          {category.name}
+        </option>
+      ))}
     </select>
   );
 };

--- a/frontend/app/pages/components/CategorySelectionPulldown.tsx
+++ b/frontend/app/pages/components/CategorySelectionPulldown.tsx
@@ -2,7 +2,7 @@
 課題1. setFilerValの型をanyから修正する
 課題2. プルダウンをハードコーディングからmst_muscle_categoryから取得できるようにする
 */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 type CategorySelectionPulldownProps = {
   setFilterVal: React.Dispatch<React.SetStateAction<number>>;
 };
@@ -19,7 +19,12 @@ const CategorySelectionPulldown = ({
   const getMstMuscleCategory = async () => {
     const response = await fetch(`http://localhost:3000/mst-muscle-category`);
     const result = response.json();
+    console.log("マスタ取得結果", result);
   };
+
+  useEffect(() => {
+    getMstMuscleCategory();
+  });
 
   return (
     <select name="category_id" onChange={(e) => setFilterVal(+e.target.value)}>

--- a/frontend/app/pages/components/CategorySelectionPulldown.tsx
+++ b/frontend/app/pages/components/CategorySelectionPulldown.tsx
@@ -16,6 +16,10 @@ const CategorySelectionPulldown = ({
   setFilterVal,
 }: CategorySelectionPulldownProps) => {
   const [trainingName, setTrainingName] = useState<MstMuscleCategory[]>([]);
+  const getMstMuscleCategory = async () => {
+    const response = await fetch(`http://localhost:3000/mst-muscle-category`);
+    const result = response.json();
+  };
 
   return (
     <select name="category_id" onChange={(e) => setFilterVal(+e.target.value)}>

--- a/frontend/app/pages/components/CategorySelectionPulldown.tsx
+++ b/frontend/app/pages/components/CategorySelectionPulldown.tsx
@@ -2,14 +2,21 @@
 課題1. setFilerValの型をanyから修正する
 課題2. プルダウンをハードコーディングからmst_muscle_categoryから取得できるようにする
 */
-import React from "react";
+import React, { useState } from "react";
 type CategorySelectionPulldownProps = {
   setFilterVal: React.Dispatch<React.SetStateAction<number>>;
+};
+
+type MstMuscleCategory = {
+  id: number;
+  name: string;
 };
 
 const CategorySelectionPulldown = ({
   setFilterVal,
 }: CategorySelectionPulldownProps) => {
+  const [trainingName, setTrainingName] = useState<MstMuscleCategory[]>([]);
+
   return (
     <select name="category_id" onChange={(e) => setFilterVal(+e.target.value)}>
       <option value="1">腹筋</option>


### PR DESCRIPTION
# Why
- ハードコーディングとなっているプルダウンの処理をapiの取得結果を表示する形に変更

# What
- [ ]  マスタを全取得するAPIを作成
- [ ]  マスタの全取得結果を保持するstateを定義
- [ ]  マスタを全取得する処理を呼び出す処理を実装
- [ ]  マスタの全取得処理をコンポーネントにレンダリング後に実行
- [ ]  マスタの全取得結果をプルダウンに表示