### PR TITLE
エラーハンドリング追加

### DIFF
--- a/backend/src/muscle/dto/create-muscle.dto.ts
+++ b/backend/src/muscle/dto/create-muscle.dto.ts
@@ -13,6 +13,6 @@ export class CreateMuscleDto {
 
   @IsNotEmpty()
   @IsInt()
-  @Min(0)
+  @Min(1)
   count: number;
 }

--- a/backend/src/muscle/dto/create-muscle.dto.ts
+++ b/backend/src/muscle/dto/create-muscle.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsNumber, IsDate, IsInt, Min } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsDate, IsPositive } from 'class-validator';
 
 export class CreateMuscleDto {
   @IsNotEmpty()
@@ -12,7 +12,6 @@ export class CreateMuscleDto {
   date: Date;
 
   @IsNotEmpty()
-  @IsInt()
-  @Min(1)
+  @IsPositive()
   count: number;
 }

--- a/backend/src/muscle/dto/create-muscle.dto.ts
+++ b/backend/src/muscle/dto/create-muscle.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsNumber, IsDate } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsDate, IsInt, Min } from 'class-validator';
 
 export class CreateMuscleDto {
   @IsNotEmpty()
@@ -12,6 +12,7 @@ export class CreateMuscleDto {
   date: Date;
 
   @IsNotEmpty()
-  @IsNumber()
+  @IsInt()
+  @Min(0)
   count: number;
 }

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -12,11 +12,21 @@ export function Top() {
   const [filterVal, setFilterVal] = useState<number>(0);
 
   const getTrainingRecord = async () => {
-    const response = await fetch("http://localhost:3000/muscle/");
-    const result = await response.json();
-    setTrainingRecord(result);
+    try {
+      const response = await fetch("http://localhost:3000/muscle/");
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+        );
+      }
+      const result = await response.json();
+      setTrainingRecord(result);
 
-    console.log(result, "test");
+      console.log(result, "test");
+    } catch (error: any) {
+      alert(`一覧取得に失敗しました。\n\n${error.message}`);
+    }
   };
 
   const getSelectCategoryId = async () => {

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -22,8 +22,6 @@ export function Top() {
       }
       const result = await response.json();
       setTrainingRecord(result);
-
-      console.log(result, "test");
     } catch (error: any) {
       alert(`一覧取得に失敗しました。\n\n${error.message}`);
     }

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -14,7 +14,7 @@ export function Top() {
   const getTrainingRecord = async () => {
     try {
       const response = await fetch("http://localhost:3000/muscle/");
-      if (!response.ok) {
+      if (response.status != 200) {
         const errorData = await response.json();
         throw new Error(
           `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
@@ -33,7 +33,7 @@ export function Top() {
         const response = await fetch(
           `http://localhost:3000/muscle/category/${filterVal}`
         );
-        if (!response.ok) {
+        if (response.status != 200) {
           const errorData = await response.json();
           throw new Error(
             `HTTP ${errorData.statusCode} エラー\n${errorData.message}`

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -31,12 +31,22 @@ export function Top() {
 
   const getSelectCategoryId = async () => {
     if (filterVal != 0) {
-      const response = await fetch(
-        `http://localhost:3000/muscle/category/${filterVal}`
-      );
-      const result = await response.json();
-      setTrainingRecord(result);
-      setCurrentPage(1);
+      try {
+        const response = await fetch(
+          `http://localhost:3000/muscle/category/${filterVal}`
+        );
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(
+            `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+          );
+        }
+        const result = await response.json();
+        setTrainingRecord(result);
+        setCurrentPage(1);
+      } catch (error: any) {
+        alert(`絞り込みに失敗しました。${error.message}`);
+      }
     }
   };
 

--- a/frontend/app/pages/components/Button.tsx
+++ b/frontend/app/pages/components/Button.tsx
@@ -2,9 +2,15 @@ type Props = {
   onClick: () => void;
   buttonName: string;
   disabled?: boolean;
+  color?: string;
 };
 
-const Button = (props: Props) => {
-  return <button onClick={props.onClick}>{props.buttonName}</button>;
+const Button = ({
+  disabled = true,
+  onClick,
+  buttonName,
+  color = "red",
+}: Props) => {
+  return <button onClick={onClick}>{buttonName}</button>;
 };
 export default Button;

--- a/frontend/app/pages/components/InputForm.tsx
+++ b/frontend/app/pages/components/InputForm.tsx
@@ -84,6 +84,7 @@ const InputForm = (props: Props) => {
         <div>
           <input
             type="number"
+            min="0"
             name="count"
             value={trainingData.count || ""}
             onChange={handleCountChange}

--- a/frontend/app/pages/components/ManageMstTrainingPage.tsx
+++ b/frontend/app/pages/components/ManageMstTrainingPage.tsx
@@ -11,10 +11,20 @@ const ManageMstTrainingPage = () => {
   const [newTraining, setNewTraining] = useState<string>("");
 
   const getMstMuscleCategory = async () => {
-    const response = await fetch("http://localhost:3000/mst-muscle-category");
-    const result = await response.json();
-    setTrainingCategory(result);
-    console.log(result);
+    try {
+      const response = await fetch("http://localhost:3000/mst-muscle-category");
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+        );
+      }
+      const result = await response.json();
+      setTrainingCategory(result);
+      console.log(result);
+    } catch (error: any) {
+      alert(`マスタ一覧の取得に失敗しました。\n\n${error.message}`);
+    }
   };
   useEffect(() => {
     getMstMuscleCategory();
@@ -23,18 +33,31 @@ const ManageMstTrainingPage = () => {
   const createNewTraining = async () => {
     console.log(newTraining);
     if (newTraining.length > 0) {
-      await fetch(`http://localhost:3000/mst-muscle-category`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: newTraining,
-        }),
-      });
-      alert("マスタへの追加が完了しました。");
-      setNewTraining("");
-      getMstMuscleCategory();
+      try {
+        const response = await fetch(
+          `http://localhost:3000/mst-muscle-category`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              name: newTraining,
+            }),
+          }
+        );
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(
+            `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+          );
+        }
+        alert("マスタへの追加が完了しました。");
+        setNewTraining("");
+        getMstMuscleCategory();
+      } catch (error: any) {
+        alert(`マスタ追加に失敗しました。\n\n${error.message}`);
+      }
     } else alert("入力画面には1文字以上の文字を入力してください");
   };
 

--- a/frontend/app/pages/components/ManageMstTrainingPage.tsx
+++ b/frontend/app/pages/components/ManageMstTrainingPage.tsx
@@ -46,7 +46,7 @@ const ManageMstTrainingPage = () => {
             }),
           }
         );
-        if (!response.ok) {
+        if (response.status != 201) {
           const errorData = await response.json();
           throw new Error(
             `HTTP ${errorData.statusCode} エラー\n${errorData.message}`

--- a/frontend/app/pages/components/UpdatePage.tsx
+++ b/frontend/app/pages/components/UpdatePage.tsx
@@ -25,7 +25,7 @@ const UpdatePage = () => {
           }),
         });
 
-        if (!response.ok) {
+        if (response.status != 200) {
           const errorData = await response.json();
           throw new Error(
             `HTTP ${errorData.statusCode} エラー \n${errorData.message}`

--- a/frontend/app/pages/components/UpdatePage.tsx
+++ b/frontend/app/pages/components/UpdatePage.tsx
@@ -34,7 +34,7 @@ const UpdatePage = () => {
         alert("更新が完了しました。");
         backTopPage();
       } catch (error: any) {
-        alert(error.message);
+        alert(`データの更新に失敗しました。\n\n${error.message}`);
       }
     } else {
       const alertMessage: string[] = [];

--- a/frontend/app/pages/components/UpdatePage.tsx
+++ b/frontend/app/pages/components/UpdatePage.tsx
@@ -12,19 +12,30 @@ const UpdatePage = () => {
     const date = formData.get("date");
     const count = formData.get("count");
     if (categoryId && date && count) {
-      await fetch(`http://localhost:3000/muscle/id/${id}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          category_id: +categoryId!,
-          date: date,
-          count: +count!,
-        }),
-      });
-      alert("更新が完了しました。");
-      backTopPage();
+      try {
+        const response = await fetch(`http://localhost:3000/muscle/id/${id}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            category_id: +categoryId!,
+            date: date,
+            count: +count!,
+          }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(
+            `HTTP ${errorData.statusCode} エラー \n${errorData.message}`
+          );
+        }
+        alert("更新が完了しました。");
+        backTopPage();
+      } catch (error: any) {
+        alert(error.message);
+      }
     } else {
       const alertMessage: string[] = [];
       if (!categoryId) {

--- a/frontend/app/pages/components/postTrainingDataPage.tsx
+++ b/frontend/app/pages/components/postTrainingDataPage.tsx
@@ -9,19 +9,29 @@ const PostTrainingDataPage = () => {
     const date = formData.get("date");
     const count = formData.get("count");
     if (categoryId && date && count) {
-      await fetch("http://localhost:3000/muscle/", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          category_id: +categoryId!,
-          date: date,
-          count: +count!,
-        }),
-      });
-      alert("登録が完了しました。");
-      backTopPage();
+      try {
+        const response = await fetch("http://localhost:3000/muscle/", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            category_id: +categoryId!,
+            date: date,
+            count: +count!,
+          }),
+        });
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(
+            `HTTP ${errorData.statusCode} エラー\n${errorData.message} `
+          );
+        }
+        alert("登録が完了しました。");
+        backTopPage();
+      } catch (error: any) {
+        alert(`${error.message}`);
+      }
     } else {
       const alertMessage: string[] = [];
       if (!categoryId) {

--- a/frontend/app/pages/components/postTrainingDataPage.tsx
+++ b/frontend/app/pages/components/postTrainingDataPage.tsx
@@ -30,7 +30,7 @@ const PostTrainingDataPage = () => {
         alert("登録が完了しました。");
         backTopPage();
       } catch (error: any) {
-        alert(`${error.message}`);
+        alert(`データの登録に失敗しました。\n\n${error.message}`);
       }
     } else {
       const alertMessage: string[] = [];

--- a/frontend/app/pages/components/postTrainingDataPage.tsx
+++ b/frontend/app/pages/components/postTrainingDataPage.tsx
@@ -21,7 +21,7 @@ const PostTrainingDataPage = () => {
             count: +count!,
           }),
         });
-        if (!response.ok) {
+        if (response.status != 201) {
           const errorData = await response.json();
           throw new Error(
             `HTTP ${errorData.statusCode} エラー\n${errorData.message} `


### PR DESCRIPTION
# Why
- api呼び出しに失敗しても完了した旨のalertが表示される不具合を修正

# What
- [ ] 筋トレ実績登録apiを呼び出し時のエラーハンドリングを追加
- [ ] 更新apiを呼び出した時のエラーハンドリングを追加
- [ ] マスタ登録画面で呼び出されるapiのエラーハンドリングを追加
- [ ] 一覧結果、一覧結果絞り込みapiを呼び出した時のエラーハンドリングを追加