### PR TITLE
種目管理画面の種目一覧表示に部位名を追加

### DIFF
--- a/backend/src/exercise-category/exercise-category.controller.ts
+++ b/backend/src/exercise-category/exercise-category.controller.ts
@@ -24,6 +24,11 @@ export class ExerciseCategoryController {
     return await this.exerciseCategoryService.findAll();
   }
 
+  @Get('with-target')
+  async findAlWithTarget() {
+    return await this.exerciseCategoryService.findAllWithTarget();
+  }
+
   @Get('target/:target_id')
   async findAllByTargetId(@Param('target_id', ParseIntPipe) targetId: number) {
     return await this.exerciseCategoryService.findAllByTargetId(targetId);

--- a/backend/src/exercise-category/exercise-category.service.ts
+++ b/backend/src/exercise-category/exercise-category.service.ts
@@ -17,6 +17,19 @@ export class ExerciseCategoryService {
       `;
     return result;
   }
+  async findAllWithTarget() {
+    const result = await this.prisma.$queryRaw`
+      SELECT
+        ec.id,
+        ta.name AS target_name,
+        ec.name AS exercise_name
+      FROM exercise_categories as ec
+      INNER JOIN target_areas AS ta
+        ON ec.target_id = ta.id
+      ORDER BY ta.id, ec.id ASC
+      `;
+    return result;
+  }
 
   async findAllByTargetId(targetId: number) {
     const result = await this.prisma.$queryRaw`

--- a/frontend/app/apiActions/exerciseCategoryManager.ts
+++ b/frontend/app/apiActions/exerciseCategoryManager.ts
@@ -2,7 +2,9 @@ import { API_BASE_URL } from "~/config";
 
 export const getExerciseCategory = async () => {
   try {
-    const response = await fetch(`${API_BASE_URL}/exercise-category`);
+    const response = await fetch(
+      `${API_BASE_URL}/exercise-category/with-target`
+    );
     if (!response.ok) {
       const errorData = await response.json();
       throw new Error(

--- a/frontend/app/pages/ExerciseCategoryManagerPage.tsx
+++ b/frontend/app/pages/ExerciseCategoryManagerPage.tsx
@@ -3,16 +3,11 @@ import Button from "~/components/parts/Button";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
 import { API_BASE_URL } from "~/config";
-import type { PulldownSelectedValue } from "~/type/common";
 import { getExerciseCategory } from "~/apiActions/exerciseCategoryManager";
 import TargetSelectionPulldown from "~/components/parts/pulldown/TargetSelectionPulldown";
+import type { ExerciseCategory } from "~/type/exercise_category";
 
 // 筋トレ種目（マスタ）登録画面を生成する関数コンポーネント
-type ExerciseCategory = {
-  id: number;
-  target_name: string;
-  exercise_name: string;
-};
 
 const ExerciseCategoryManagerPage = () => {
   const [exerciseCategory, setExerciseCategory] = useState<ExerciseCategory[]>(

--- a/frontend/app/pages/ExerciseCategoryManagerPage.tsx
+++ b/frontend/app/pages/ExerciseCategoryManagerPage.tsx
@@ -5,12 +5,15 @@ import Sidebar from "~/components/common/Sidebar";
 import { API_BASE_URL } from "~/config";
 import type { PulldownSelectedValue } from "~/type/common";
 import { getExerciseCategory } from "~/apiActions/exerciseCategoryManager";
+import TargetSelectionPulldown from "~/components/parts/pulldown/TargetSelectionPulldown";
 
 // 筋トレ種目（マスタ）登録画面を生成する関数コンポーネント
 const ExerciseCategoryManagerPage = () => {
   const [exerciseCategory, setExerciseCategory] = useState<
     PulldownSelectedValue[]
   >([]);
+  // 部位IDを保持するstateを追加
+  const [selectedTargetId, setSelectedTargetId] = useState<number>(0);
   const [newExerciseCategory, setNewExerciseCategory] = useState<string>("");
 
   useEffect(() => {
@@ -30,6 +33,7 @@ const ExerciseCategoryManagerPage = () => {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
+            target_id: selectedTargetId,
             name: newExerciseCategory,
           }),
         });
@@ -45,7 +49,16 @@ const ExerciseCategoryManagerPage = () => {
       } catch (error: any) {
         alert(`マスタ追加に失敗しました。\n\n${error.message}`);
       }
-    } else alert("入力画面には1文字以上の文字を入力してください");
+    } else {
+      const alertMessage: string[] = [];
+      if (!selectedTargetId) {
+        alertMessage.push("部位を選択してください");
+      }
+      if (!newExerciseCategory) {
+        alertMessage.push("入力画面には1文字以上の文字を入力してください");
+      }
+      alert(alertMessage.join("\n"));
+    }
   };
 
   // 5ページ単位のページネーション
@@ -92,6 +105,10 @@ const ExerciseCategoryManagerPage = () => {
         <div className="content">
           <h1>トレーニング種目マスタ</h1>
           <div>
+            <TargetSelectionPulldown
+              filterTarget={selectedTargetId}
+              setFilterTarget={setSelectedTargetId}
+            />
             <input
               type="text"
               value={newExerciseCategory}

--- a/frontend/app/pages/ExerciseCategoryManagerPage.tsx
+++ b/frontend/app/pages/ExerciseCategoryManagerPage.tsx
@@ -8,10 +8,16 @@ import { getExerciseCategory } from "~/apiActions/exerciseCategoryManager";
 import TargetSelectionPulldown from "~/components/parts/pulldown/TargetSelectionPulldown";
 
 // 筋トレ種目（マスタ）登録画面を生成する関数コンポーネント
+type ExerciseCategory = {
+  id: number;
+  target_name: string;
+  exercise_name: string;
+};
+
 const ExerciseCategoryManagerPage = () => {
-  const [exerciseCategory, setExerciseCategory] = useState<
-    PulldownSelectedValue[]
-  >([]);
+  const [exerciseCategory, setExerciseCategory] = useState<ExerciseCategory[]>(
+    []
+  );
   // 部位IDを保持するstateを追加
   const [selectedTargetId, setSelectedTargetId] = useState<number>(0);
   const [newExerciseCategory, setNewExerciseCategory] = useState<string>("");
@@ -119,6 +125,7 @@ const ExerciseCategoryManagerPage = () => {
           <table>
             <thead>
               <tr>
+                <th className="training-name-header">部位名</th>
                 <th className="training-name-header">種目名</th>
               </tr>
             </thead>
@@ -127,7 +134,10 @@ const ExerciseCategoryManagerPage = () => {
                 return (
                   <tr key={index}>
                     <th className="training-name-record">
-                      {trainingName.name}
+                      {trainingName.target_name}
+                    </th>
+                    <th className="training-name-record">
+                      {trainingName.exercise_name}
                     </th>
                   </tr>
                 );

--- a/frontend/app/type/exercise_category.ts
+++ b/frontend/app/type/exercise_category.ts
@@ -1,0 +1,5 @@
+export type ExerciseCategory = {
+  id: number;
+  target_name: string;
+  exercise_name: string;
+};


### PR DESCRIPTION
# Why
- 種目管理画面の種目一覧表示に部位名を追加

# What
- [ ] 部位名と種目名の一覧を取得するapiを追加
- [ ] apiで取得した情報を管理するuseStateの型を変更
- [ ] 種目管理画面で読んでいたapiを種目名の一覧を取得するものから部位名と種目名の一覧を取得するものに変更
- [ ] 呼び出し元に定義していた型をtypeディレクトリに移動