### PR TITLE
登録、更新ページのapi呼び出し処理を親コンポーネントに集約

### DIFF
--- a/frontend/app/apiActions/TargetArea.ts
+++ b/frontend/app/apiActions/TargetArea.ts
@@ -1,0 +1,18 @@
+import { API_BASE_URL } from "~/config";
+
+// 部位リストを取得処理呼び出し関数
+export const getTargetAreaList = async () => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/target-area`);
+    if (response.status != 200) {
+      const errorData = await response.json();
+      throw new Error(
+        `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+      );
+    }
+    const result = await response.json();
+    return { success: true, data: result };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+};

--- a/frontend/app/apiActions/TargetArea.ts
+++ b/frontend/app/apiActions/TargetArea.ts
@@ -16,3 +16,26 @@ export const getTargetAreaList = async () => {
     return { success: false, error: error.message };
   }
 };
+
+export const getExerciseCategoryByTargetId = async (target_id: number) => {
+  try {
+    let response;
+    if (target_id && target_id > 0) {
+      response = await fetch(
+        `${API_BASE_URL}/exercise-category/target/${target_id}`
+      );
+    } else {
+      response = await fetch(`${API_BASE_URL}/exercise-category`);
+    }
+    if (response.status != 200) {
+      const errorData = await response.json();
+      throw new Error(
+        `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+      );
+    }
+    const result = await response.json();
+    return { success: true, data: result };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+};

--- a/frontend/app/apiActions/holidaysApi.ts
+++ b/frontend/app/apiActions/holidaysApi.ts
@@ -1,0 +1,18 @@
+// 祝日取得api呼び出し関数
+export const getHolidayList = async () => {
+  try {
+    const response = await fetch(
+      "https://holidays-jp.github.io/api/v1/date.json"
+    );
+    if (response.status != 200) {
+      const errorData = await response.json();
+      throw new Error(
+        `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+      );
+    }
+    const result = await response.json();
+    return { success: true, data: result };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+};

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -89,3 +89,8 @@ header {
 .pagination {
   margin: 10px 15px;
 }
+
+.holiday {
+  background-color: #fff0f0;
+  color: #d10000;
+}

--- a/frontend/app/components/InputForm.tsx
+++ b/frontend/app/components/InputForm.tsx
@@ -80,7 +80,7 @@ const InputForm = (props: Props) => {
             name="target_id"
             options={props.targetOptions}
             value={props.trainingRecord.target_id}
-            handleValueChange={handleTargetId}
+            onChange={handleTargetId}
           />
         </div>
         <div>
@@ -89,7 +89,7 @@ const InputForm = (props: Props) => {
             name="exercise_id"
             options={props.exerciseOptions}
             value={props.trainingRecord.exercise_id}
-            handleValueChange={handleExerciseId}
+            onChange={handleExerciseId}
           />
         </div>
         <div>

--- a/frontend/app/components/InputForm.tsx
+++ b/frontend/app/components/InputForm.tsx
@@ -2,12 +2,11 @@ import type { TrainingRecordWithExerciseId } from "~/type/training_record";
 import Button from "./parts/Button";
 import ExerciseSelectionPulldown from "./parts/pulldown/ExerciseSelectionPulldown";
 import TargetSelectionPulldown from "./parts/pulldown/TargetSelectionPulldown";
+import type { PulldownSelectedValue } from "~/type/common";
 
 type Props = {
-  filterVal: number;
-  setFilterVal: React.Dispatch<React.SetStateAction<number>>;
-  filterTarget: number;
-  setFilterTarget: React.Dispatch<React.SetStateAction<number>>;
+  exerciseOptions: PulldownSelectedValue[];
+  targetOptions: PulldownSelectedValue[];
   trainingRecord: TrainingRecordWithExerciseId;
   setTrainingRecord: React.Dispatch<
     React.SetStateAction<TrainingRecordWithExerciseId>
@@ -32,6 +31,25 @@ const InputForm = (props: Props) => {
     });
   };
 
+  // 部位IDの変更状態を管理するハンドラー
+  const handleTargetId = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newTargetIdStr = e.target.value;
+    const newTargetId = newTargetIdStr === "" ? 0 : +newTargetIdStr;
+    props.setTrainingRecord({
+      ...props.trainingRecord,
+      target_id: newTargetId,
+    });
+  };
+
+  // 種目IDの変更状態を管理するハンドラー
+  const handleExerciseId = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newExerciseIdStr = e.target.value;
+    const newExerciseId = newExerciseIdStr === "" ? 0 : +newExerciseIdStr;
+    props.setTrainingRecord({
+      ...props.trainingRecord,
+      exercise_id: newExerciseId,
+    });
+  };
   // 重量の変更状態を管理するハンドラー
   const handleWeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newWeightStr = e.target.value;
@@ -58,21 +76,18 @@ const InputForm = (props: Props) => {
       <form action={props.onClick}>
         <div>
           <span>部位 </span>
-          <TargetSelectionPulldown //部位選択プルダウン用の追加
-            filterTarget={props.filterTarget}
-            setFilterTarget={props.setFilterTarget}
-            trainingRecord={props.trainingRecord}
-            setTrainingRecord={props.setTrainingRecord}
+          <TargetSelectionPulldown
+            options={props.targetOptions}
+            value={props.trainingRecord.target_id}
+            handleValueChange={handleTargetId}
           />
         </div>
         <div>
           <span>種目 </span>
           <ExerciseSelectionPulldown
-            filterTarget={props.filterTarget} // プルダウンに部位に紐づく種目のみを表示するために追加
-            filterExercise={props.filterVal}
-            setFilterExercise={props.setFilterVal}
-            trainingRecord={props.trainingRecord}
-            setTrainingRecord={props.setTrainingRecord}
+            options={props.exerciseOptions}
+            value={props.trainingRecord.exercise_id}
+            handleValueChange={handleExerciseId}
           />
         </div>
         <div>

--- a/frontend/app/components/InputForm.tsx
+++ b/frontend/app/components/InputForm.tsx
@@ -77,6 +77,7 @@ const InputForm = (props: Props) => {
         <div>
           <span>部位 </span>
           <TargetSelectionPulldown
+            name="target_id"
             options={props.targetOptions}
             value={props.trainingRecord.target_id}
             handleValueChange={handleTargetId}
@@ -85,6 +86,7 @@ const InputForm = (props: Props) => {
         <div>
           <span>種目 </span>
           <ExerciseSelectionPulldown
+            name="exercise_id"
             options={props.exerciseOptions}
             value={props.trainingRecord.exercise_id}
             handleValueChange={handleExerciseId}

--- a/frontend/app/components/common/Sidebar.tsx
+++ b/frontend/app/components/common/Sidebar.tsx
@@ -8,6 +8,10 @@ const Sidebar = () => {
   const backTopPage = () => {
     navigate("/");
   };
+  // 一覧画面に遷移
+  const navigateToTrainingRecordListPage = () => {
+    navigate("/list");
+  };
   // 登録画面に遷移
   const navigateToTrainingRecordEditPage = () => {
     navigate("/create");
@@ -19,7 +23,13 @@ const Sidebar = () => {
   return (
     <aside className="sidebar">
       <div className="sidebar-content">
-        <Button onClick={backTopPage} buttonName="筋トレ実績へ" />
+        <Button onClick={backTopPage} buttonName="トップページへ" />
+      </div>
+      <div className="sidebar-content">
+        <Button
+          onClick={navigateToTrainingRecordListPage}
+          buttonName="実績一覧"
+        />
       </div>
       <div className="sidebar-content">
         <Button

--- a/frontend/app/components/parts/pulldown/BaseSelectionPulldown.tsx
+++ b/frontend/app/components/parts/pulldown/BaseSelectionPulldown.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { PulldownSelectedValue } from "~/type/common";
 
 type BaseSelectionPulldownProps = {
+  optionId: string;
   filterVal: number;
   handleValueChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   selectedValues: PulldownSelectedValue[];
@@ -9,12 +10,13 @@ type BaseSelectionPulldownProps = {
 
 // プルダウンを生成する関数コンポーネント
 const BaseSelectionPulldown = ({
+  optionId,
   filterVal,
   handleValueChange,
   selectedValues,
 }: BaseSelectionPulldownProps) => {
   return (
-    <select name="exercise_id" value={filterVal} onChange={handleValueChange}>
+    <select name={optionId} value={filterVal} onChange={handleValueChange}>
       <option value="">選択してください</option>
       {selectedValues.map((value) => (
         <option key={value.id} value={value.id}>

--- a/frontend/app/components/parts/pulldown/BaseSelectionPulldown.tsx
+++ b/frontend/app/components/parts/pulldown/BaseSelectionPulldown.tsx
@@ -4,7 +4,7 @@ import type { PulldownSelectedValue } from "~/type/common";
 type BaseSelectionPulldownProps = {
   optionId: string;
   filterVal: number;
-  handleValueChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   selectedValues: PulldownSelectedValue[];
 };
 
@@ -12,11 +12,11 @@ type BaseSelectionPulldownProps = {
 const BaseSelectionPulldown = ({
   optionId,
   filterVal,
-  handleValueChange,
+  onChange,
   selectedValues,
 }: BaseSelectionPulldownProps) => {
   return (
-    <select name={optionId} value={filterVal} onChange={handleValueChange}>
+    <select name={optionId} value={filterVal} onChange={onChange}>
       <option value="">選択してください</option>
       {selectedValues.map((value) => (
         <option key={value.id} value={value.id}>

--- a/frontend/app/components/parts/pulldown/ExerciseSelectionPulldown.tsx
+++ b/frontend/app/components/parts/pulldown/ExerciseSelectionPulldown.tsx
@@ -3,6 +3,7 @@ import BaseSelectionPulldown from "./BaseSelectionPulldown";
 import type { PulldownSelectedValue } from "~/type/common";
 
 type TargetSelectionPulldownProps = {
+  name: string;
   options: PulldownSelectedValue[];
   value: number;
   handleValueChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -10,12 +11,14 @@ type TargetSelectionPulldownProps = {
 
 // 種目選択のプルダウンを生成する関数コンポーネント
 const TargetSelectionPulldown = ({
+  name,
   options,
   value,
   handleValueChange,
 }: TargetSelectionPulldownProps) => {
   return (
     <BaseSelectionPulldown
+      optionId={name}
       filterVal={value}
       handleValueChange={handleValueChange}
       selectedValues={options || []}

--- a/frontend/app/components/parts/pulldown/ExerciseSelectionPulldown.tsx
+++ b/frontend/app/components/parts/pulldown/ExerciseSelectionPulldown.tsx
@@ -1,69 +1,25 @@
-import React, { useEffect, useState } from "react";
-import type { TrainingRecordWithExerciseId } from "~/type/training_record";
+import React from "react";
 import BaseSelectionPulldown from "./BaseSelectionPulldown";
-import { API_BASE_URL } from "~/config";
 import type { PulldownSelectedValue } from "~/type/common";
 
-type ExerciseSelectionPulldownProps = {
-  filterTarget?: number;
-  filterExercise: number;
-  setFilterExercise: React.Dispatch<React.SetStateAction<number>>;
-  trainingRecord?: TrainingRecordWithExerciseId;
-  setTrainingRecord?: React.Dispatch<
-    React.SetStateAction<TrainingRecordWithExerciseId>
-  >;
+type TargetSelectionPulldownProps = {
+  options: PulldownSelectedValue[];
+  value: number;
+  handleValueChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
 // 種目選択のプルダウンを生成する関数コンポーネント
-const ExerciseSelectionPulldown = ({
-  filterExercise,
-  filterTarget,
-  setFilterExercise,
-  trainingRecord,
-  setTrainingRecord,
-}: ExerciseSelectionPulldownProps) => {
-  // 種目名を取得
-  const [selectedValues, setSelectedValues] = useState<PulldownSelectedValue[]>(
-    []
-  );
-  const apiEndPoint =
-    filterTarget && filterTarget > 0
-      ? `exercise-category/target/${filterTarget}`
-      : "exercise-category";
-  useEffect(() => {
-    (async () => {
-      const response = await fetch(`${API_BASE_URL}/${apiEndPoint}`);
-      const result = await response.json();
-      setSelectedValues(result);
-      console.log("エンドポイント: ", apiEndPoint, ": 取得結果", result);
-    })();
-  }, [apiEndPoint]);
-  // 種目の変更状態を管理するハンドラー
-  const handleExerciseIdChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newExerciseIdStr = e.target.value;
-    const newExerciseId = newExerciseIdStr === "" ? 0 : +newExerciseIdStr;
-
-    // 登録、更新画面でのプルダウン表示
-    if (trainingRecord !== undefined && setTrainingRecord !== undefined) {
-      setTrainingRecord!({
-        ...trainingRecord!,
-        exercise_id: newExerciseId,
-      });
-      // 筋トレ実績画面でのプルダウン表示
-    } else {
-      setFilterExercise(newExerciseId);
-      console.log(
-        "エンドポイント: ",
-        `exercise-category/target/${filterTarget}`
-      );
-    }
-  };
+const TargetSelectionPulldown = ({
+  options,
+  value,
+  handleValueChange,
+}: TargetSelectionPulldownProps) => {
   return (
     <BaseSelectionPulldown
-      filterVal={filterExercise}
-      handleValueChange={handleExerciseIdChange}
-      selectedValues={selectedValues}
+      filterVal={value}
+      handleValueChange={handleValueChange}
+      selectedValues={options || []}
     />
   );
 };
-export default ExerciseSelectionPulldown;
+export default TargetSelectionPulldown;

--- a/frontend/app/components/parts/pulldown/ExerciseSelectionPulldown.tsx
+++ b/frontend/app/components/parts/pulldown/ExerciseSelectionPulldown.tsx
@@ -6,7 +6,7 @@ type TargetSelectionPulldownProps = {
   name: string;
   options: PulldownSelectedValue[];
   value: number;
-  handleValueChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
 // 種目選択のプルダウンを生成する関数コンポーネント
@@ -14,13 +14,13 @@ const TargetSelectionPulldown = ({
   name,
   options,
   value,
-  handleValueChange,
+  onChange,
 }: TargetSelectionPulldownProps) => {
   return (
     <BaseSelectionPulldown
       optionId={name}
       filterVal={value}
-      handleValueChange={handleValueChange}
+      onChange={onChange}
       selectedValues={options || []}
     />
   );

--- a/frontend/app/components/parts/pulldown/TargetSelectionPulldown.tsx
+++ b/frontend/app/components/parts/pulldown/TargetSelectionPulldown.tsx
@@ -3,6 +3,7 @@ import BaseSelectionPulldown from "./BaseSelectionPulldown";
 import type { PulldownSelectedValue } from "~/type/common";
 
 type TargetSelectionPulldownProps = {
+  name: string;
   options: PulldownSelectedValue[];
   value: number;
   handleValueChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -10,12 +11,14 @@ type TargetSelectionPulldownProps = {
 
 // 部位選択のプルダウンを生成する関数コンポーネント
 const TargetSelectionPulldown = ({
+  name,
   options,
   value,
   handleValueChange,
 }: TargetSelectionPulldownProps) => {
   return (
     <BaseSelectionPulldown
+      optionId={name}
       filterVal={value}
       handleValueChange={handleValueChange}
       selectedValues={options || []}

--- a/frontend/app/components/parts/pulldown/TargetSelectionPulldown.tsx
+++ b/frontend/app/components/parts/pulldown/TargetSelectionPulldown.tsx
@@ -6,7 +6,7 @@ type TargetSelectionPulldownProps = {
   name: string;
   options: PulldownSelectedValue[];
   value: number;
-  handleValueChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
 // 部位選択のプルダウンを生成する関数コンポーネント
@@ -14,13 +14,13 @@ const TargetSelectionPulldown = ({
   name,
   options,
   value,
-  handleValueChange,
+  onChange,
 }: TargetSelectionPulldownProps) => {
   return (
     <BaseSelectionPulldown
       optionId={name}
       filterVal={value}
-      handleValueChange={handleValueChange}
+      onChange={onChange}
       selectedValues={options || []}
     />
   );

--- a/frontend/app/components/parts/pulldown/TargetSelectionPulldown.tsx
+++ b/frontend/app/components/parts/pulldown/TargetSelectionPulldown.tsx
@@ -1,61 +1,24 @@
-import React, { useEffect, useState } from "react";
-import type { TrainingRecordWithExerciseId } from "~/type/training_record";
+import React from "react";
 import BaseSelectionPulldown from "./BaseSelectionPulldown";
 import type { PulldownSelectedValue } from "~/type/common";
-import { API_BASE_URL } from "~/config";
 
 type TargetSelectionPulldownProps = {
-  filterTarget: number;
-  setFilterTarget: React.Dispatch<React.SetStateAction<number>>;
-  trainingRecord?: TrainingRecordWithExerciseId;
-  setTrainingRecord?: React.Dispatch<
-    React.SetStateAction<TrainingRecordWithExerciseId>
-  >;
+  options: PulldownSelectedValue[];
+  value: number;
+  handleValueChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
-// 種目選択のプルダウンを生成する関数コンポーネント
+// 部位選択のプルダウンを生成する関数コンポーネント
 const TargetSelectionPulldown = ({
-  filterTarget,
-  setFilterTarget,
-  trainingRecord,
-  setTrainingRecord,
+  options,
+  value,
+  handleValueChange,
 }: TargetSelectionPulldownProps) => {
-  // 部位名を取得
-  const [selectedValues, setSelectedValues] = useState<PulldownSelectedValue[]>(
-    []
-  );
-  const apiEndPoint = "target-area";
-  useEffect(() => {
-    (async () => {
-      const response = await fetch(`${API_BASE_URL}/${apiEndPoint}`);
-      const result = await response.json();
-      setSelectedValues(result);
-      console.log("エンドポイント: ", apiEndPoint, ": 取得結果", result);
-    })();
-  }, [apiEndPoint]);
-
-  // 種目の変更状態を管理するハンドラー
-  const handleTargetIdChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newTargetIdStr = e.target.value;
-    const newTargetId = newTargetIdStr === "" ? 0 : +newTargetIdStr;
-
-    // 登録、更新画面でのプルダウン表示
-    if (trainingRecord !== undefined && setTrainingRecord !== undefined) {
-      setTrainingRecord!({
-        ...trainingRecord!,
-        target_id: newTargetId,
-      });
-      // 筋トレ実績画面でのプルダウン表示
-    } else {
-      setFilterTarget(newTargetId);
-      console.log("filterTarget: ", filterTarget);
-    }
-  };
   return (
     <BaseSelectionPulldown
-      filterVal={filterTarget}
-      handleValueChange={handleTargetIdChange}
-      selectedValues={selectedValues}
+      filterVal={value}
+      handleValueChange={handleValueChange}
+      selectedValues={options || []}
     />
   );
 };

--- a/frontend/app/pages/ExerciseCategoryManagerPage.tsx
+++ b/frontend/app/pages/ExerciseCategoryManagerPage.tsx
@@ -8,6 +8,8 @@ import {
 } from "~/apiActions/exerciseCategoryManager";
 import TargetSelectionPulldown from "~/components/parts/pulldown/TargetSelectionPulldown";
 import type { ExerciseCategory } from "~/type/exercise_category";
+import type { PulldownSelectedValue } from "~/type/common";
+import { getTargetAreaList } from "~/apiActions/TargetArea";
 
 // 筋トレ種目（マスタ）登録画面を生成する関数コンポーネント
 const ExerciseCategoryManagerPage = () => {
@@ -17,6 +19,19 @@ const ExerciseCategoryManagerPage = () => {
   // 部位IDを保持するstateを追加
   const [selectedTargetId, setSelectedTargetId] = useState<number>(0);
   const [newExerciseCategory, setNewExerciseCategory] = useState<string>("");
+
+  // 部位選択プルダウン用のstate
+  const [targetOptions, setTargetOptions] = useState<PulldownSelectedValue[]>(
+    []
+  );
+
+  // 部位リストを取得
+  useEffect(() => {
+    (async () => {
+      const result = await getTargetAreaList();
+      setTargetOptions(result.data);
+    })();
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -87,8 +102,10 @@ const ExerciseCategoryManagerPage = () => {
           <h1>トレーニング種目マスタ</h1>
           <div>
             <TargetSelectionPulldown
-              filterTarget={selectedTargetId}
-              setFilterTarget={setSelectedTargetId}
+              name="target_id"
+              options={targetOptions}
+              value={selectedTargetId}
+              onChange={(e) => setSelectedTargetId(+e.target.value)}
             />
             <input
               type="text"

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -1,22 +1,19 @@
-import { Calendar } from "primereact/Calendar";
 import { useState } from "react";
+import Calendar from "react-calendar";
+import "react-calendar/dist/Calendar.css";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
 
 // トップページを生成する関数コンポーネント
 export function Top() {
-  const [date, setDate] = useState<any>();
-  // カスタムロケール設定
-  const customLocale = {
-    dayNamesShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-  };
+  const [date, setDate] = useState<Date | null>(new Date());
   return (
     <div className="layout">
       <Header />
       <div className="main-content">
         <Sidebar />
         <div className="content">
-          <Calendar value={date} onChange={(e) => setDate(e.value)} inline />
+          <Calendar value={date} onClickDay={(e) => setDate(e)} />
         </div>
       </div>
     </div>

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -6,14 +6,19 @@ import Sidebar from "~/components/common/Sidebar";
 
 // トップページを生成する関数コンポーネント
 export function Top() {
-  const [date, setDate] = useState<Date | null>(new Date());
+  const [date, setDate] = useState<Date | null>(new Date()); // 初期値は今日の日付
   return (
     <div className="layout">
       <Header />
       <div className="main-content">
         <Sidebar />
         <div className="content">
-          <Calendar value={date} onClickDay={(e) => setDate(e)} />
+          <Calendar
+            value={date}
+            onClickDay={(e) => setDate(e)} // 選択した日にポインタを当てる
+            calendarType="gregory" // 日曜始り、土日休日とするためにグレゴリオ歴を指定
+            locale="en-US" // 日付の「日」の表示を消すために、英語ロケールを使用
+          />
         </div>
       </div>
     </div>

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -1,12 +1,43 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
+import { getHolidayList } from "~/apiActions/holidaysApi";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
 
 // トップページを生成する関数コンポーネント
 export function Top() {
   const [date, setDate] = useState<Date | null>(new Date()); // 初期値は今日の日付
+  const [holidays, setHolidays] = useState<Record<string, string>>({});
+
+  // APIから祝日データを取得
+  useEffect(() => {
+    (async () => {
+      const result = await getHolidayList();
+      if (result.success) {
+        setHolidays(result.data);
+      }
+    })();
+  }, []);
+
+  // 祝日かどうか判定
+  const isHoliday = (date: Date) => {
+    // Dateオブジェクトから「年」を取得
+    const year = date.getFullYear();
+    // Dateオブジェクトから「月」を2桁の文字列で取得
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    // Dateオブジェクトから「日」を2桁の文字列で取得
+    const day = String(date.getDate()).padStart(2, "0");
+    // 日本時間（JST）で「YYYY-MM-DD」形式の文字列を作成
+    const dateStr = `${year}-${month}-${day}`;
+    return dateStr in holidays;
+  };
+
+  // カレンダーの日付セルにクラスを付与
+  const tileClassName = ({ date, view }: { date: Date; view: string }) => {
+    if (view !== "month") return "";
+    return isHoliday(date) ? "holiday" : "";
+  };
   return (
     <div className="layout">
       <Header />
@@ -18,6 +49,7 @@ export function Top() {
             onClickDay={(e) => setDate(e)} // 選択した日にポインタを当てる
             calendarType="gregory" // 日曜始り、土日休日とするためにグレゴリオ歴を指定
             locale="en-US" // 日付の「日」の表示を消すために、英語ロケールを使用
+            tileClassName={tileClassName}
           />
         </div>
       </div>

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -1,15 +1,22 @@
+import { Calendar } from "primereact/Calendar";
+import { useState } from "react";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
 
 // トップページを生成する関数コンポーネント
 export function Top() {
+  const [date, setDate] = useState<any>();
+  // カスタムロケール設定
+  const customLocale = {
+    dayNamesShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+  };
   return (
     <div className="layout">
       <Header />
       <div className="main-content">
         <Sidebar />
         <div className="content">
-          <h1>トップページ</h1>
+          <Calendar value={date} onChange={(e) => setDate(e.value)} inline />
         </div>
       </div>
     </div>

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -1,152 +1,15 @@
-import { useEffect, useState } from "react";
-import TrainingRecordTable from "~/components/features/top/TrainingRecordTable";
-import Button from "~/components/parts/Button";
-import ExerciseSelectionPulldown from "~/components/parts/pulldown/ExerciseSelectionPulldown";
-import type {
-  TrainingRecordWithExerciseId,
-  TrainingRecordWithName,
-} from "~/type/training_record";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
-import TargetSelectionPulldown from "~/components/parts/pulldown/TargetSelectionPulldown";
-import {
-  getSelectExerciseId,
-  getTrainingRecord,
-} from "~/apiActions/TrainingRecord";
-import type { PulldownSelectedValue } from "~/type/common";
-import {
-  getExerciseCategoryByTargetId,
-  getTargetAreaList,
-} from "~/apiActions/TargetArea";
 
 // トップページを生成する関数コンポーネント
 export function Top() {
-  const [trainingRecords, setTrainingRecords] = useState<
-    TrainingRecordWithName[]
-  >([]);
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  // 部位選択プルダウン用のstate
-  const [targetOptions, setTargetOptions] = useState<PulldownSelectedValue[]>(
-    []
-  );
-  // 種目選択プルダウン用のstate
-  const [exerciseOptions, setExerciseOptions] = useState<
-    PulldownSelectedValue[]
-  >([]);
-  const [trainingRecord, setTrainingRecord] =
-    useState<TrainingRecordWithExerciseId>({
-      id: 0,
-      target_id: 0,
-      exercise_id: 0,
-      date: new Date(),
-      weight: 0,
-      count: 0,
-    });
-
-  // 一覧取得処理呼び出し
-  const handleGetTrainingRecord = async () => {
-    const result = await getTrainingRecord();
-    if (result.success) {
-      setTrainingRecords(result.data);
-      setCurrentPage(1);
-    } else {
-      alert(`一覧取得に失敗しました。\n\n${result.error}`);
-    }
-  };
-
-  // 絞り込み表示処理呼び出し
-  const handleGetSelectExerciseId = async () => {
-    const result = await getSelectExerciseId(trainingRecord.exercise_id);
-    if (result.success) {
-      setTrainingRecords(result.data);
-      setCurrentPage(1);
-    } else {
-      alert(`絞り込みに失敗しました。${result.error}`);
-    }
-  };
-
-  // 部位IDの変更状態を管理するハンドラー
-  const handleTargetId = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newTargetIdStr = e.target.value;
-    const newTargetId = newTargetIdStr === "" ? 0 : +newTargetIdStr;
-    setTrainingRecord({
-      ...trainingRecord,
-      target_id: newTargetId,
-    });
-  };
-
-  // 種目IDの変更状態を管理するハンドラー
-  const handleExerciseId = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newExerciseIdStr = e.target.value;
-    const newExerciseId = newExerciseIdStr === "" ? 0 : +newExerciseIdStr;
-    setTrainingRecord({
-      ...trainingRecord,
-      exercise_id: newExerciseId,
-    });
-  };
-
-  useEffect(() => {
-    (async () => {
-      const result = await getTrainingRecord();
-      if (result.success) {
-        setTrainingRecords(result.data);
-      } else {
-        alert(`一覧取得に失敗しました。\n\n${result.error}`);
-      }
-    })();
-  }, []);
-
-  // 部位IDが変わったら種目リスト取得
-  useEffect(() => {
-    (async () => {
-      // 部位リストを取得
-      const result = await getTargetAreaList();
-      setTargetOptions(result.data);
-
-      if (trainingRecord.target_id && trainingRecord.target_id > 0) {
-        const result = await getExerciseCategoryByTargetId(
-          trainingRecord.target_id
-        );
-        if (result.success) {
-          setExerciseOptions(result.data);
-        } else {
-          alert(`部位に対応する種目の取得に失敗しました。${result.error}`);
-        }
-      }
-    })();
-  }, [trainingRecord.target_id]);
-
   return (
     <div className="layout">
       <Header />
       <div className="main-content">
         <Sidebar />
         <div className="content">
-          <h1>筋トレ実績</h1>
-          <div>
-            <Button onClick={handleGetTrainingRecord} buttonName="一覧取得" />
-          </div>
-          <div>
-            <Button onClick={handleGetSelectExerciseId} buttonName="絞り込み" />
-            <TargetSelectionPulldown
-              name="target_id"
-              options={targetOptions}
-              value={trainingRecord.target_id}
-              onChange={handleTargetId}
-            />
-            <ExerciseSelectionPulldown
-              name="exercise_id"
-              options={exerciseOptions}
-              value={trainingRecord.exercise_id}
-              onChange={handleExerciseId}
-            />
-          </div>
-          <TrainingRecordTable
-            trainingRecord={trainingRecords}
-            currentPage={currentPage}
-            getTrainingRecord={getTrainingRecord}
-            setCurrentPage={setCurrentPage}
-          />
+          <h1>トップページ</h1>
         </div>
       </div>
     </div>

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from "react";
 import TrainingRecordTable from "~/components/features/top/TrainingRecordTable";
 import Button from "~/components/parts/Button";
 import ExerciseSelectionPulldown from "~/components/parts/pulldown/ExerciseSelectionPulldown";
-import type { TrainingRecordWithName } from "~/type/training_record";
+import type {
+  TrainingRecordWithExerciseId,
+  TrainingRecordWithName,
+} from "~/type/training_record";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
 import TargetSelectionPulldown from "~/components/parts/pulldown/TargetSelectionPulldown";
@@ -10,22 +13,41 @@ import {
   getSelectExerciseId,
   getTrainingRecord,
 } from "~/apiActions/TrainingRecord";
+import type { PulldownSelectedValue } from "~/type/common";
+import {
+  getExerciseCategoryByTargetId,
+  getTargetAreaList,
+} from "~/apiActions/TargetArea";
 
 // トップページを生成する関数コンポーネント
 export function Top() {
-  const [trainingRecord, setTrainingRecord] = useState<
+  const [trainingRecords, setTrainingRecords] = useState<
     TrainingRecordWithName[]
   >([]);
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [filterExercise, setFilterExercise] = useState<number>(0);
-  // 部位選択プルダウン用のstateを追加
-  const [filterTarget, setFilterTarget] = useState<number>(0);
+  // 部位選択プルダウン用のstate
+  const [targetOptions, setTargetOptions] = useState<PulldownSelectedValue[]>(
+    []
+  );
+  // 種目選択プルダウン用のstate
+  const [exerciseOptions, setExerciseOptions] = useState<
+    PulldownSelectedValue[]
+  >([]);
+  const [trainingRecord, setTrainingRecord] =
+    useState<TrainingRecordWithExerciseId>({
+      id: 0,
+      target_id: 0,
+      exercise_id: 0,
+      date: new Date(),
+      weight: 0,
+      count: 0,
+    });
 
   // 一覧取得処理呼び出し
   const handleGetTrainingRecord = async () => {
     const result = await getTrainingRecord();
     if (result.success) {
-      setTrainingRecord(result.data);
+      setTrainingRecords(result.data);
       setCurrentPage(1);
     } else {
       alert(`一覧取得に失敗しました。\n\n${result.error}`);
@@ -34,25 +56,65 @@ export function Top() {
 
   // 絞り込み表示処理呼び出し
   const handleGetSelectExerciseId = async () => {
-    const result = await getSelectExerciseId(filterExercise);
+    const result = await getSelectExerciseId(trainingRecord.exercise_id);
     if (result.success) {
-      setTrainingRecord(result.data);
+      setTrainingRecords(result.data);
       setCurrentPage(1);
     } else {
       alert(`絞り込みに失敗しました。${result.error}`);
     }
   };
 
+  // 部位IDの変更状態を管理するハンドラー
+  const handleTargetId = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newTargetIdStr = e.target.value;
+    const newTargetId = newTargetIdStr === "" ? 0 : +newTargetIdStr;
+    setTrainingRecord({
+      ...trainingRecord,
+      target_id: newTargetId,
+    });
+  };
+
+  // 種目IDの変更状態を管理するハンドラー
+  const handleExerciseId = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newExerciseIdStr = e.target.value;
+    const newExerciseId = newExerciseIdStr === "" ? 0 : +newExerciseIdStr;
+    setTrainingRecord({
+      ...trainingRecord,
+      exercise_id: newExerciseId,
+    });
+  };
+
   useEffect(() => {
     (async () => {
       const result = await getTrainingRecord();
       if (result.success) {
-        setTrainingRecord(result.data);
+        setTrainingRecords(result.data);
       } else {
         alert(`一覧取得に失敗しました。\n\n${result.error}`);
       }
     })();
   }, []);
+
+  // 部位IDが変わったら種目リスト取得
+  useEffect(() => {
+    (async () => {
+      // 部位リストを取得
+      const result = await getTargetAreaList();
+      setTargetOptions(result.data);
+
+      if (trainingRecord.target_id && trainingRecord.target_id > 0) {
+        const result = await getExerciseCategoryByTargetId(
+          trainingRecord.target_id
+        );
+        if (result.success) {
+          setExerciseOptions(result.data);
+        } else {
+          alert(`部位に対応する種目の取得に失敗しました。${result.error}`);
+        }
+      }
+    })();
+  }, [trainingRecord.target_id]);
 
   return (
     <div className="layout">
@@ -66,18 +128,21 @@ export function Top() {
           </div>
           <div>
             <Button onClick={handleGetSelectExerciseId} buttonName="絞り込み" />
-            <TargetSelectionPulldown //部位選択プルダウン用の追加
-              filterTarget={filterTarget}
-              setFilterTarget={setFilterTarget}
+            <TargetSelectionPulldown
+              name="target_id"
+              options={targetOptions}
+              value={trainingRecord.target_id}
+              onChange={handleTargetId}
             />
             <ExerciseSelectionPulldown
-              filterExercise={filterExercise}
-              filterTarget={filterTarget}
-              setFilterExercise={setFilterExercise}
+              name="exercise_id"
+              options={exerciseOptions}
+              value={trainingRecord.exercise_id}
+              onChange={handleExerciseId}
             />
           </div>
           <TrainingRecordTable
-            trainingRecord={trainingRecord}
+            trainingRecord={trainingRecords}
             currentPage={currentPage}
             getTrainingRecord={getTrainingRecord}
             setCurrentPage={setCurrentPage}

--- a/frontend/app/pages/TrainingRecordCreatePage.tsx
+++ b/frontend/app/pages/TrainingRecordCreatePage.tsx
@@ -5,6 +5,8 @@ import Sidebar from "~/components/common/Sidebar";
 import { useEffect, useState } from "react";
 import type { TrainingRecordWithExerciseId } from "~/type/training_record";
 import { createTrainingRecord } from "~/apiActions/TrainingRecord";
+import type { PulldownSelectedValue } from "~/type/common";
+import { API_BASE_URL } from "~/config";
 
 // 筋トレ実績登録画面を生成する関数コンポーネント
 const TrainingRecordCreatePage = () => {
@@ -13,10 +15,14 @@ const TrainingRecordCreatePage = () => {
   const backTopPage = () => {
     navigate("/");
   };
-
-  const [filterVal, setFilterVal] = useState<number>(0);
-  // 部位選択プルダウン用のstateを追加
-  const [filterTarget, setFilterTarget] = useState<number>(0);
+  // 部位選択プルダウン用のstate
+  const [targetOptions, setTargetOptions] = useState<PulldownSelectedValue[]>(
+    []
+  );
+  // 種目選択プルダウン用のstate
+  const [exerciseOptions, setExerciseOptions] = useState<
+    PulldownSelectedValue[]
+  >([]);
   const [trainingRecord, setTrainingRecord] =
     useState<TrainingRecordWithExerciseId>({
       id: 0,
@@ -27,11 +33,29 @@ const TrainingRecordCreatePage = () => {
       count: 0,
     });
 
+  // 部位IDが変わったら種目リスト取得
   useEffect(() => {
-    setFilterTarget(trainingRecord.target_id);
-    setFilterVal(trainingRecord.exercise_id);
-    console.log("stateの値:", trainingRecord);
-  }, [trainingRecord]);
+    (async () => {
+      // 部位リストを取得
+      const response = await fetch(`${API_BASE_URL}/target-area`);
+      const result = await response.json();
+      setTargetOptions(result);
+
+      if (trainingRecord.target_id && trainingRecord.target_id > 0) {
+        const exerciseResponse = await fetch(
+          `${API_BASE_URL}/exercise-category/target/${trainingRecord.target_id}`
+        );
+        const exerciseResult = await exerciseResponse.json();
+        setExerciseOptions(exerciseResult);
+      } else {
+        const exerciseResponse = await fetch(
+          `${API_BASE_URL}/exercise-category`
+        );
+        const exerciseResult = await exerciseResponse.json();
+        setExerciseOptions(exerciseResult);
+      }
+    })();
+  }, [trainingRecord.target_id]);
 
   // トレーニング記録登録に必要なデータの取得
   const handleCreate = async (formData: FormData) => {
@@ -63,10 +87,8 @@ const TrainingRecordCreatePage = () => {
         <Sidebar />
         <div className="content">
           <InputForm
-            filterVal={filterVal}
-            setFilterVal={setFilterVal}
-            filterTarget={filterTarget}
-            setFilterTarget={setFilterTarget}
+            exerciseOptions={exerciseOptions}
+            targetOptions={targetOptions}
             trainingRecord={trainingRecord}
             setTrainingRecord={setTrainingRecord}
             onClick={handleCreate}

--- a/frontend/app/pages/TrainingRecordCreatePage.tsx
+++ b/frontend/app/pages/TrainingRecordCreatePage.tsx
@@ -7,6 +7,7 @@ import type { TrainingRecordWithExerciseId } from "~/type/training_record";
 import { createTrainingRecord } from "~/apiActions/TrainingRecord";
 import type { PulldownSelectedValue } from "~/type/common";
 import { API_BASE_URL } from "~/config";
+import { getTargetAreaList } from "~/apiActions/TargetArea";
 
 // 筋トレ実績登録画面を生成する関数コンポーネント
 const TrainingRecordCreatePage = () => {
@@ -37,9 +38,8 @@ const TrainingRecordCreatePage = () => {
   useEffect(() => {
     (async () => {
       // 部位リストを取得
-      const response = await fetch(`${API_BASE_URL}/target-area`);
-      const result = await response.json();
-      setTargetOptions(result);
+      const result = await getTargetAreaList();
+      setTargetOptions(result.data);
 
       if (trainingRecord.target_id && trainingRecord.target_id > 0) {
         const exerciseResponse = await fetch(

--- a/frontend/app/pages/TrainingRecordCreatePage.tsx
+++ b/frontend/app/pages/TrainingRecordCreatePage.tsx
@@ -6,8 +6,10 @@ import { useEffect, useState } from "react";
 import type { TrainingRecordWithExerciseId } from "~/type/training_record";
 import { createTrainingRecord } from "~/apiActions/TrainingRecord";
 import type { PulldownSelectedValue } from "~/type/common";
-import { API_BASE_URL } from "~/config";
-import { getTargetAreaList } from "~/apiActions/TargetArea";
+import {
+  getExerciseCategoryByTargetId,
+  getTargetAreaList,
+} from "~/apiActions/TargetArea";
 
 // 筋トレ実績登録画面を生成する関数コンポーネント
 const TrainingRecordCreatePage = () => {
@@ -42,17 +44,14 @@ const TrainingRecordCreatePage = () => {
       setTargetOptions(result.data);
 
       if (trainingRecord.target_id && trainingRecord.target_id > 0) {
-        const exerciseResponse = await fetch(
-          `${API_BASE_URL}/exercise-category/target/${trainingRecord.target_id}`
+        const result = await getExerciseCategoryByTargetId(
+          trainingRecord.target_id
         );
-        const exerciseResult = await exerciseResponse.json();
-        setExerciseOptions(exerciseResult);
-      } else {
-        const exerciseResponse = await fetch(
-          `${API_BASE_URL}/exercise-category`
-        );
-        const exerciseResult = await exerciseResponse.json();
-        setExerciseOptions(exerciseResult);
+        if (result.success) {
+          setExerciseOptions(result.data);
+        } else {
+          alert(`部位に対応する種目の取得に失敗しました。${result.error}`);
+        }
       }
     })();
   }, [trainingRecord.target_id]);

--- a/frontend/app/pages/TrainingRecordEditPage.tsx
+++ b/frontend/app/pages/TrainingRecordEditPage.tsx
@@ -1,5 +1,5 @@
-import InputForm from "~/components/InputForm";
 import { useNavigate, useParams } from "react-router";
+import InputForm from "~/components/InputForm";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
 import { useEffect, useState } from "react";
@@ -8,14 +8,26 @@ import {
   getTrainingRecordById,
   updateTrainingRecord,
 } from "~/apiActions/TrainingRecord";
+import type { PulldownSelectedValue } from "~/type/common";
+import { API_BASE_URL } from "~/config";
 
 // 筋トレ記録更新画面を生成する関数コンポーネント
 const TrainingRecordEditPage = () => {
   // URL から id を取得
   const { id } = useParams<{ id: string }>();
-  const [filterVal, setFilterVal] = useState<number>(0);
-  // 部位選択プルダウン用のstateを追加
-  const [filterTarget, setFilterTarget] = useState<number>(0);
+  // トップ画面に戻るための処理
+  const navigate = useNavigate();
+  const backTopPage = () => {
+    navigate("/");
+  };
+  // 部位選択プルダウン用のstate
+  const [targetOptions, setTargetOptions] = useState<PulldownSelectedValue[]>(
+    []
+  );
+  // 種目選択プルダウン用のstate
+  const [exerciseOptions, setExerciseOptions] = useState<
+    PulldownSelectedValue[]
+  >([]);
   const [trainingRecord, setTrainingRecord] =
     useState<TrainingRecordWithExerciseId>({
       id: 0,
@@ -36,11 +48,27 @@ const TrainingRecordEditPage = () => {
     })();
   }, []);
   useEffect(() => {
-    setFilterTarget(trainingRecord.target_id);
-    setFilterVal(trainingRecord.exercise_id);
-    console.log("stateの値:", trainingRecord);
-  }, [trainingRecord]);
+    (async () => {
+      // 部位リストを取得
+      const response = await fetch(`${API_BASE_URL}/target-area`);
+      const result = await response.json();
+      setTargetOptions(result);
 
+      if (trainingRecord.target_id && trainingRecord.target_id > 0) {
+        const exerciseResponse = await fetch(
+          `${API_BASE_URL}/exercise-category/target/${trainingRecord.target_id}`
+        );
+        const exerciseResult = await exerciseResponse.json();
+        setExerciseOptions(exerciseResult);
+      } else {
+        const exerciseResponse = await fetch(
+          `${API_BASE_URL}/exercise-category`
+        );
+        const exerciseResult = await exerciseResponse.json();
+        setExerciseOptions(exerciseResult);
+      }
+    })();
+  }, [trainingRecord.target_id]);
   // 筋トレ記録更新処理呼び出し
   const handleUpdate = async (formData: FormData) => {
     const exerciseId = formData.get("exercise_id");
@@ -48,6 +76,7 @@ const TrainingRecordEditPage = () => {
     const weight = formData.get("weight");
     const count = formData.get("count");
 
+    // トレーニング記録登録処理呼び出し
     const response = await updateTrainingRecord({
       id: +id!,
       exercise_id: +exerciseId!,
@@ -60,13 +89,8 @@ const TrainingRecordEditPage = () => {
       alert("更新が完了しました。");
       backTopPage();
     } else {
-      alert(`データの登録に失敗しました。\n\n${response.error}`);
+      alert(`データの更新に失敗しました。\n\n${response.error}`);
     }
-  };
-
-  const navigate = useNavigate();
-  const backTopPage = () => {
-    navigate("/");
   };
 
   return (
@@ -76,10 +100,8 @@ const TrainingRecordEditPage = () => {
         <Sidebar />
         <div className="content">
           <InputForm
-            filterVal={filterVal}
-            setFilterVal={setFilterVal}
-            filterTarget={filterTarget}
-            setFilterTarget={setFilterTarget}
+            exerciseOptions={exerciseOptions}
+            targetOptions={targetOptions}
             trainingRecord={trainingRecord}
             setTrainingRecord={setTrainingRecord}
             onClick={handleUpdate}

--- a/frontend/app/pages/TrainingRecordEditPage.tsx
+++ b/frontend/app/pages/TrainingRecordEditPage.tsx
@@ -9,7 +9,10 @@ import {
   updateTrainingRecord,
 } from "~/apiActions/TrainingRecord";
 import type { PulldownSelectedValue } from "~/type/common";
-import { API_BASE_URL } from "~/config";
+import {
+  getExerciseCategoryByTargetId,
+  getTargetAreaList,
+} from "~/apiActions/TargetArea";
 
 // 筋トレ記録更新画面を生成する関数コンポーネント
 const TrainingRecordEditPage = () => {
@@ -47,25 +50,23 @@ const TrainingRecordEditPage = () => {
       }
     })();
   }, []);
+
+  // 部位IDが変わったら種目リスト取得
   useEffect(() => {
     (async () => {
       // 部位リストを取得
-      const response = await fetch(`${API_BASE_URL}/target-area`);
-      const result = await response.json();
-      setTargetOptions(result);
+      const result = await getTargetAreaList();
+      setTargetOptions(result.data);
 
       if (trainingRecord.target_id && trainingRecord.target_id > 0) {
-        const exerciseResponse = await fetch(
-          `${API_BASE_URL}/exercise-category/target/${trainingRecord.target_id}`
+        const result = await getExerciseCategoryByTargetId(
+          trainingRecord.target_id
         );
-        const exerciseResult = await exerciseResponse.json();
-        setExerciseOptions(exerciseResult);
-      } else {
-        const exerciseResponse = await fetch(
-          `${API_BASE_URL}/exercise-category`
-        );
-        const exerciseResult = await exerciseResponse.json();
-        setExerciseOptions(exerciseResult);
+        if (result.success) {
+          setExerciseOptions(result.data);
+        } else {
+          alert(`部位に対応する種目の取得に失敗しました。${result.error}`);
+        }
       }
     })();
   }, [trainingRecord.target_id]);

--- a/frontend/app/pages/TrainingRecordListPage.tsx
+++ b/frontend/app/pages/TrainingRecordListPage.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import TrainingRecordTable from "~/components/features/top/TrainingRecordTable";
+import Button from "~/components/parts/Button";
+import ExerciseSelectionPulldown from "~/components/parts/pulldown/ExerciseSelectionPulldown";
+import type {
+  TrainingRecordWithExerciseId,
+  TrainingRecordWithName,
+} from "~/type/training_record";
+import Header from "~/components/common/Header";
+import Sidebar from "~/components/common/Sidebar";
+import TargetSelectionPulldown from "~/components/parts/pulldown/TargetSelectionPulldown";
+import {
+  getSelectExerciseId,
+  getTrainingRecord,
+} from "~/apiActions/TrainingRecord";
+import type { PulldownSelectedValue } from "~/type/common";
+import {
+  getExerciseCategoryByTargetId,
+  getTargetAreaList,
+} from "~/apiActions/TargetArea";
+
+// トップページを生成する関数コンポーネント
+const TrainingRecordListPage = () => {
+  const [trainingRecords, setTrainingRecords] = useState<
+    TrainingRecordWithName[]
+  >([]);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  // 部位選択プルダウン用のstate
+  const [targetOptions, setTargetOptions] = useState<PulldownSelectedValue[]>(
+    []
+  );
+  // 種目選択プルダウン用のstate
+  const [exerciseOptions, setExerciseOptions] = useState<
+    PulldownSelectedValue[]
+  >([]);
+  const [trainingRecord, setTrainingRecord] =
+    useState<TrainingRecordWithExerciseId>({
+      id: 0,
+      target_id: 0,
+      exercise_id: 0,
+      date: new Date(),
+      weight: 0,
+      count: 0,
+    });
+
+  // 一覧取得処理呼び出し
+  const handleGetTrainingRecord = async () => {
+    const result = await getTrainingRecord();
+    if (result.success) {
+      setTrainingRecords(result.data);
+      setCurrentPage(1);
+    } else {
+      alert(`一覧取得に失敗しました。\n\n${result.error}`);
+    }
+  };
+
+  // 絞り込み表示処理呼び出し
+  const handleGetSelectExerciseId = async () => {
+    const result = await getSelectExerciseId(trainingRecord.exercise_id);
+    if (result.success) {
+      setTrainingRecords(result.data);
+      setCurrentPage(1);
+    } else {
+      alert(`絞り込みに失敗しました。${result.error}`);
+    }
+  };
+
+  // 部位IDの変更状態を管理するハンドラー
+  const handleTargetId = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newTargetIdStr = e.target.value;
+    const newTargetId = newTargetIdStr === "" ? 0 : +newTargetIdStr;
+    setTrainingRecord({
+      ...trainingRecord,
+      target_id: newTargetId,
+    });
+  };
+
+  // 種目IDの変更状態を管理するハンドラー
+  const handleExerciseId = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newExerciseIdStr = e.target.value;
+    const newExerciseId = newExerciseIdStr === "" ? 0 : +newExerciseIdStr;
+    setTrainingRecord({
+      ...trainingRecord,
+      exercise_id: newExerciseId,
+    });
+  };
+
+  useEffect(() => {
+    (async () => {
+      const result = await getTrainingRecord();
+      if (result.success) {
+        setTrainingRecords(result.data);
+      } else {
+        alert(`一覧取得に失敗しました。\n\n${result.error}`);
+      }
+    })();
+  }, []);
+
+  // 部位IDが変わったら種目リスト取得
+  useEffect(() => {
+    (async () => {
+      // 部位リストを取得
+      const result = await getTargetAreaList();
+      setTargetOptions(result.data);
+
+      if (trainingRecord.target_id && trainingRecord.target_id > 0) {
+        const result = await getExerciseCategoryByTargetId(
+          trainingRecord.target_id
+        );
+        if (result.success) {
+          setExerciseOptions(result.data);
+        } else {
+          alert(`部位に対応する種目の取得に失敗しました。${result.error}`);
+        }
+      }
+    })();
+  }, [trainingRecord.target_id]);
+
+  return (
+    <div className="layout">
+      <Header />
+      <div className="main-content">
+        <Sidebar />
+        <div className="content">
+          <h1>筋トレ実績</h1>
+          <div>
+            <Button onClick={handleGetTrainingRecord} buttonName="一覧取得" />
+          </div>
+          <div>
+            <Button onClick={handleGetSelectExerciseId} buttonName="絞り込み" />
+            <TargetSelectionPulldown
+              name="target_id"
+              options={targetOptions}
+              value={trainingRecord.target_id}
+              onChange={handleTargetId}
+            />
+            <ExerciseSelectionPulldown
+              name="exercise_id"
+              options={exerciseOptions}
+              value={trainingRecord.exercise_id}
+              onChange={handleExerciseId}
+            />
+          </div>
+          <TrainingRecordTable
+            trainingRecord={trainingRecords}
+            currentPage={currentPage}
+            getTrainingRecord={getTrainingRecord}
+            setCurrentPage={setCurrentPage}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+export default TrainingRecordListPage;

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -2,6 +2,7 @@ import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
 export default [
   route("/", "routes/home.tsx"),
+  route("list", "routes/TrainingRecordList.tsx"),
   route("create", "routes/TrainingRecordCreate.tsx"),
   route("update/:id", "routes/TrainingRecordEdit.tsx"),
   route("exercise-category/", "routes/ExerciseCategoryManager.tsx"),

--- a/frontend/app/routes/TrainingRecordList.tsx
+++ b/frontend/app/routes/TrainingRecordList.tsx
@@ -1,0 +1,18 @@
+import TrainingRecordListPage from "~/pages/TrainingRecordListPage";
+import type { Route } from "../+types/root";
+
+import Title from "~/utils/Title";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    {
+      title: Title.title,
+      description: Title.description,
+      content: Title.content,
+    },
+  ];
+}
+
+export default function TrainingRecordList() {
+  return <TrainingRecordListPage />;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
         "@react-router/node": "^7.5.0",
         "@react-router/serve": "^7.5.0",
         "isbot": "^5.1.17",
+        "primeicons": "^7.0.0",
+        "primereact": "^10.9.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.5.0"
@@ -465,7 +467,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -2573,7 +2574,6 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
       "integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2594,6 +2594,15 @@
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
       "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
       "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
@@ -3211,7 +3220,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -4289,7 +4297,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -4598,7 +4605,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4920,7 +4926,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5130,6 +5135,35 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/primeicons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-7.0.0.tgz",
+      "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==",
+      "license": "MIT"
+    },
+    "node_modules/primereact": {
+      "version": "10.9.6",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.9.6.tgz",
+      "integrity": "sha512-0Jjz/KzfUURSHaPTXJwjL2Dc7CDPnbO17MivyJz7T5smGAMLY5d+IqpQhV61R22G/rDmhMh3+32LCNva2M8fRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-transition-group": "^4.4.1",
+        "react-transition-group": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -5172,7 +5206,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5318,7 +5351,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
@@ -5550,6 +5582,32 @@
         "react-dom": ">=16.14.0"
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-transition-group/node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -5591,7 +5649,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,8 @@
         "@react-router/node": "^7.5.0",
         "@react-router/serve": "^7.5.0",
         "isbot": "^5.1.17",
-        "primeicons": "^7.0.0",
-        "primereact": "^10.9.6",
         "react": "^19.0.0",
+        "react-calendar": "^6.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.5.0"
       },
@@ -467,6 +466,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -2574,6 +2574,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
       "integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2599,13 +2600,13 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-2.0.2.tgz",
+      "integrity": "sha512-Do66mSlSNifFFuo3l9gNKfRMSFi26CRuQMsDJuuKO/ekrDWuTTtE4ZQxoFCUOG+NgxnpSeBq/k5TY8ZseEzLpA==",
       "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*"
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
     "node_modules/abbrev": {
@@ -2998,7 +2999,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3220,6 +3220,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -3985,6 +3986,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-3.0.0.tgz",
+      "integrity": "sha512-iJfHSmdYV39UUBw7Jq6GJzeJxUr4U+S03qdhVuDsR9gCEnfbqLy9gYDJFBJQL1riqolFUKQvx36mEkp2iGgJ3g==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize": "^10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -4641,6 +4654,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+      "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/memoize-one": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
@@ -4706,6 +4734,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -4926,6 +4966,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5135,35 +5176,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/primeicons": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-7.0.0.tgz",
-      "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==",
-      "license": "MIT"
-    },
-    "node_modules/primereact": {
-      "version": "10.9.6",
-      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.9.6.tgz",
-      "integrity": "sha512-0Jjz/KzfUURSHaPTXJwjL2Dc7CDPnbO17MivyJz7T5smGAMLY5d+IqpQhV61R22G/rDmhMh3+32LCNva2M8fRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react-transition-group": "^4.4.1",
-        "react-transition-group": "^4.4.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -5206,6 +5218,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5281,6 +5294,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-calendar": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-6.0.0.tgz",
+      "integrity": "sha512-6wqaki3Us0DNDjZDr0DYIzhSFprNoy4FdPT9Pjy5aD2hJJVjtJwmdMT9VmrTUo949nlk35BOxehThxX62RkuRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^2.0.2",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^3.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-calendar/node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/react-d3-tree": {
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/react-d3-tree/-/react-d3-tree-3.6.6.tgz",
@@ -5351,6 +5398,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
@@ -5582,32 +5630,6 @@
         "react-dom": ">=16.14.0"
       }
     },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/react-transition-group/node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -5649,6 +5671,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,8 @@
     "@react-router/node": "^7.5.0",
     "@react-router/serve": "^7.5.0",
     "isbot": "^5.1.17",
-    "primeicons": "^7.0.0",
-    "primereact": "^10.9.6",
     "react": "^19.0.0",
+    "react-calendar": "^6.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.5.0"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
     "@react-router/node": "^7.5.0",
     "@react-router/serve": "^7.5.0",
     "isbot": "^5.1.17",
+    "primeicons": "^7.0.0",
+    "primereact": "^10.9.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.5.0"


### PR DESCRIPTION
# Why
- 登録、更新ページのapi呼び出し処理を親コンポーネントに集約

# What
- [ ] TargetSelectionPulldownコンポーネントのデータ取得処理をページ呼び出し側で行うように修正
- [ ] ExerciseSelectionPulldownコンポーネントのデータ取得処理をページ呼び出し側で行うように修正
- [ ] BaseSelectionPulldownコンポーネントの修正に伴い、トレーニングマスタ管理画面のstateを修正
- [ ] 筋トレ実績画面と筋トレ記録登録、更新画面のstate管理の記述を統一
- [ ] 関数名、変数名を一部統一
- [ ] 筋トレ実績一覧を別画面に移行
- [ ] トップ画面にカレンダーを表示