### PR TITLE
複数ある筋トレ記録取得APIをクエリパラメータを使ってまとめる

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,7 +8,7 @@ async function bootstrap() {
     origin: '*', // 許可するオリジン
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE', // 許可する HTTP メソッド
   });
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/backend/src/training-record/dto/get-training-record.dto.ts
+++ b/backend/src/training-record/dto/get-training-record.dto.ts
@@ -1,12 +1,12 @@
 import { Type } from 'class-transformer';
-import { IsOptional, IsPositive, IsString } from 'class-validator';
+import { IsDateString, IsOptional, IsPositive } from 'class-validator';
 
 export class TrainingRecordDto {
   @Type(() => Number)
   @IsPositive()
   @IsOptional()
   exercise_id?: number;
-  @IsString()
+  @IsDateString()
   @IsOptional()
   date?: string;
 }

--- a/backend/src/training-record/dto/get-training-record.dto.ts
+++ b/backend/src/training-record/dto/get-training-record.dto.ts
@@ -1,6 +1,8 @@
+import { Type } from 'class-transformer';
 import { IsOptional, IsPositive, IsString } from 'class-validator';
 
 export class TrainingRecordDto {
+  @Type(() => Number)
   @IsPositive()
   @IsOptional()
   exercise_id?: number;

--- a/backend/src/training-record/dto/get-training-record.dto.ts
+++ b/backend/src/training-record/dto/get-training-record.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsPositive, IsString } from 'class-validator';
+
+export class TrainingRecordDto {
+  @IsPositive()
+  @IsOptional()
+  exercise_id?: number;
+  @IsString()
+  @IsOptional()
+  date?: string;
+}

--- a/backend/src/training-record/training_record.controller.ts
+++ b/backend/src/training-record/training_record.controller.ts
@@ -11,22 +11,15 @@ import {
 } from '@nestjs/common';
 import { TrainingRecordService } from './training_record.service';
 import { CreateTrainingRecordDto } from './dto/create-training-record.dto';
+import { TrainingRecordDto } from './dto/get-training-record.dto';
 
 @Controller('training-record')
 export class TrainingRecordController {
   constructor(private readonly trainingRecordService: TrainingRecordService) {}
 
   @Get()
-  async findAll(
-    @Query('exercise_id') exerciseId?: number,
-    @Query('date') date?: string,
-  ) {
-    if (exerciseId) {
-      return await this.trainingRecordService.findAllByExerciseId(+exerciseId);
-    } else if (date) {
-      return await this.trainingRecordService.findByDate(date);
-    }
-    return await this.trainingRecordService.findAll();
+  async findAll(@Query() trainingRecordDto: TrainingRecordDto) {
+    return await this.trainingRecordService.findAll(trainingRecordDto);
   }
 
   @Get(':id')

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -48,7 +48,7 @@ export class TrainingRecordService {
   }
 
   async findById(id: number) {
-    const response = await this.prisma.trainingRecord.findMany({
+    const response = await this.prisma.trainingRecord.findUnique({
       where: { id },
       include: {
         exerciseCategories: {
@@ -58,15 +58,16 @@ export class TrainingRecordService {
         },
       },
     });
-    const result = response.map((record) => ({
-      id: record.id,
-      target_id: record.exerciseCategories?.targetId,
-      exercise_id: record.exerciseId,
-      date: record.date,
-      weight: record.weight,
-      count: record.count,
-    }));
-    return result[0];
+    if (!response) return null;
+    const result = {
+      id: response.id,
+      target_id: response.exerciseCategories?.targetId,
+      exercise_id: response.exerciseId,
+      date: response.date,
+      weight: response.weight,
+      count: response.count,
+    };
+    return result;
   }
 
   async create(createTrainingRecordDto: CreateTrainingRecordDto) {

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { CreateTrainingRecordDto } from './dto/create-training-record.dto';
 import { PrismaService } from 'src/prisma.service';
 import { TrainingData } from 'src/types';
-import { formatInTimeZone, toZonedTime } from 'date-fns-tz';
+import { formatInTimeZone } from 'date-fns-tz';
 import { TrainingRecordDto } from './dto/get-training-record.dto';
 
 @Injectable()

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -3,27 +3,66 @@ import { CreateTrainingRecordDto } from './dto/create-training-record.dto';
 import { PrismaService } from 'src/prisma.service';
 import { TrainingData } from 'src/types';
 import { formatInTimeZone, toZonedTime } from 'date-fns-tz';
+import { TrainingRecordDto } from './dto/get-training-record.dto';
 
 @Injectable()
 export class TrainingRecordService {
   constructor(private prisma: PrismaService) {}
 
-  async findAll() {
-    const result = await this.prisma.$queryRaw`
-    SELECT
-      tr.id,
-      tr.date,
-      tr.weight,
-      tr.count,
-      ec.name
-    FROM training_records as tr
-    INNER JOIN
-      exercise_categories as ec
-    ON tr.exercise_id = ec.id
-    ORDER BY tr.date DESC;
-    `;
+  async findAll(trainingRecordDto: TrainingRecordDto) {
+    // dto取り出し
+    const exercise_id = trainingRecordDto.exercise_id;
+    const date = trainingRecordDto.date;
+
+    // where条件の組み立て
+    const where: any = {};
+    if (exercise_id !== undefined) {
+      where.exerciseId = exercise_id;
+    }
+    if (date !== undefined) {
+      where.date = new Date(date);
+    }
+
+    const response = await this.prisma.trainingRecord.findMany({
+      where,
+      include: {
+        exerciseCategories: {
+          select: {
+            name: true,
+          },
+        },
+      },
+      orderBy: {
+        date: 'desc',
+      },
+    });
+    // フロントが期待する形に変換
+    const result = response.map((record) => ({
+      id: record.id,
+      date: record.date,
+      weight: record.weight,
+      count: record.count,
+      name: record.exerciseCategories?.name,
+    }));
     return result;
   }
+
+  // async findAll() {
+  //   const result = await this.prisma.$queryRaw`
+  //   SELECT
+  //     tr.id,
+  //     tr.date,
+  //     tr.weight,
+  //     tr.count,
+  //     ec.name
+  //   FROM training_records as tr
+  //   INNER JOIN
+  //     exercise_categories as ec
+  //   ON tr.exercise_id = ec.id
+  //   ORDER BY tr.date DESC;
+  //   `;
+  //   return result;
+  // }
 
   async findAllByExerciseId(exerciseId: number) {
     const result = await this.prisma.$queryRaw`

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -47,40 +47,6 @@ export class TrainingRecordService {
     return result;
   }
 
-  // async findAll() {
-  //   const result = await this.prisma.$queryRaw`
-  //   SELECT
-  //     tr.id,
-  //     tr.date,
-  //     tr.weight,
-  //     tr.count,
-  //     ec.name
-  //   FROM training_records as tr
-  //   INNER JOIN
-  //     exercise_categories as ec
-  //   ON tr.exercise_id = ec.id
-  //   ORDER BY tr.date DESC;
-  //   `;
-  //   return result;
-  // }
-
-  // async findAllByExerciseId(exerciseId: number) {
-  //   const result = await this.prisma.$queryRaw`
-  //   SELECT
-  //     tr.id,
-  //     ec.name,
-  //     tr.date,
-  //     tr.weight,
-  //     tr.count
-  //   FROM training_records as tr
-  //   INNER JOIN exercise_categories as ec
-  //   ON ec.id = tr.exercise_id
-  //   WHERE tr.exercise_id = ${exerciseId}
-  //   ORDER BY tr.date DESC;
-  //   `;
-  //   return result;
-  // }
-
   async findById(id: number) {
     const result = await this.prisma.$queryRaw<TrainingData[]>`
     SELECT
@@ -97,22 +63,6 @@ export class TrainingRecordService {
     `;
     return result[0];
   }
-
-  // async findByDate(date: string) {
-  //   const result = await this.prisma.$queryRaw`
-  //     SELECT
-  //       tr.id,
-  //       ec.name,
-  //       tr.date,
-  //       tr.weight,
-  //       tr.count
-  //     FROM training_records AS tr
-  //     INNER JOIN exercise_categories AS ec
-  //     ON tr.exercise_id = ec.id
-  //     WHERE tr.date = ${date}::DATE;
-  //     `;
-  //   return result;
-  // }
 
   async create(createTrainingRecordDto: CreateTrainingRecordDto) {
     const currentJstTime = formatInTimeZone(

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -64,22 +64,22 @@ export class TrainingRecordService {
   //   return result;
   // }
 
-  async findAllByExerciseId(exerciseId: number) {
-    const result = await this.prisma.$queryRaw`
-    SELECT
-      tr.id,
-      ec.name,
-      tr.date,
-      tr.weight,
-      tr.count
-    FROM training_records as tr
-    INNER JOIN exercise_categories as ec
-    ON ec.id = tr.exercise_id
-    WHERE tr.exercise_id = ${exerciseId}
-    ORDER BY tr.date DESC;
-    `;
-    return result;
-  }
+  // async findAllByExerciseId(exerciseId: number) {
+  //   const result = await this.prisma.$queryRaw`
+  //   SELECT
+  //     tr.id,
+  //     ec.name,
+  //     tr.date,
+  //     tr.weight,
+  //     tr.count
+  //   FROM training_records as tr
+  //   INNER JOIN exercise_categories as ec
+  //   ON ec.id = tr.exercise_id
+  //   WHERE tr.exercise_id = ${exerciseId}
+  //   ORDER BY tr.date DESC;
+  //   `;
+  //   return result;
+  // }
 
   async findById(id: number) {
     const result = await this.prisma.$queryRaw<TrainingData[]>`
@@ -98,21 +98,21 @@ export class TrainingRecordService {
     return result[0];
   }
 
-  async findByDate(date: string) {
-    const result = await this.prisma.$queryRaw`
-      SELECT
-        tr.id,
-        ec.name,
-        tr.date,
-        tr.weight,
-        tr.count
-      FROM training_records AS tr
-      INNER JOIN exercise_categories AS ec
-      ON tr.exercise_id = ec.id
-      WHERE tr.date = ${date}::DATE;
-      `;
-    return result;
-  }
+  // async findByDate(date: string) {
+  //   const result = await this.prisma.$queryRaw`
+  //     SELECT
+  //       tr.id,
+  //       ec.name,
+  //       tr.date,
+  //       tr.weight,
+  //       tr.count
+  //     FROM training_records AS tr
+  //     INNER JOIN exercise_categories AS ec
+  //     ON tr.exercise_id = ec.id
+  //     WHERE tr.date = ${date}::DATE;
+  //     `;
+  //   return result;
+  // }
 
   async create(createTrainingRecordDto: CreateTrainingRecordDto) {
     const currentJstTime = formatInTimeZone(

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -69,23 +69,6 @@ export class TrainingRecordService {
     return result[0];
   }
 
-  // async findById(id: number) {
-  //   const result = await this.prisma.$queryRaw<TrainingData[]>`
-  //   SELECT
-  //     tr.id,
-  //     ec.target_id,
-  //     tr.exercise_id,
-  //     tr.date,
-  //     tr.weight,
-  //     tr.count
-  //   FROM training_records as tr
-  //   INNER JOIN exercise_categories as ec
-  //   ON ec.id = tr.exercise_id
-  //   WHERE tr.id = ${id}
-  //   `;
-  //   return result[0];
-  // }
-
   async create(createTrainingRecordDto: CreateTrainingRecordDto) {
     const currentJstTime = formatInTimeZone(
       new Date(),

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -48,21 +48,43 @@ export class TrainingRecordService {
   }
 
   async findById(id: number) {
-    const result = await this.prisma.$queryRaw<TrainingData[]>`
-    SELECT
-      tr.id,
-      ec.target_id,
-      tr.exercise_id,
-      tr.date,
-      tr.weight,
-      tr.count
-    FROM training_records as tr
-    INNER JOIN exercise_categories as ec
-    ON ec.id = tr.exercise_id
-    WHERE tr.id = ${id}
-    `;
+    const response = await this.prisma.trainingRecord.findMany({
+      where: { id },
+      include: {
+        exerciseCategories: {
+          select: {
+            targetId: true,
+          },
+        },
+      },
+    });
+    const result = response.map((record) => ({
+      id: record.id,
+      target_id: record.exerciseCategories?.targetId,
+      exercise_id: record.exerciseId,
+      date: record.date,
+      weight: record.weight,
+      count: record.count,
+    }));
     return result[0];
   }
+
+  // async findById(id: number) {
+  //   const result = await this.prisma.$queryRaw<TrainingData[]>`
+  //   SELECT
+  //     tr.id,
+  //     ec.target_id,
+  //     tr.exercise_id,
+  //     tr.date,
+  //     tr.weight,
+  //     tr.count
+  //   FROM training_records as tr
+  //   INNER JOIN exercise_categories as ec
+  //   ON ec.id = tr.exercise_id
+  //   WHERE tr.id = ${id}
+  //   `;
+  //   return result[0];
+  // }
 
   async create(createTrainingRecordDto: CreateTrainingRecordDto) {
     const currentJstTime = formatInTimeZone(

--- a/frontend/app/apiActions/TrainingRecord.ts
+++ b/frontend/app/apiActions/TrainingRecord.ts
@@ -1,10 +1,22 @@
 import { API_BASE_URL } from "~/config";
 
 // 筋トレ実績一覧取得処理呼び出し
-export const getTrainingRecord = async () => {
+export const getTrainingRecord = async (options?: {
+  exercise_id?: any;
+  date?: string;
+}) => {
+  const params = new URLSearchParams();
+  // exercise_idが1以上のときのみパラメータに追加
+  if (options?.exercise_id && options.exercise_id > 0)
+    params.append("exercise_id", String(options.exercise_id));
+  if (options?.date) params.append("date", options.date);
+
+  const url = `${API_BASE_URL}/training-record/${
+    params.toString() ? "?" + params.toString() : ""
+  }`;
   try {
-    const response = await fetch(`${API_BASE_URL}/training-record/`);
-    if (response.status != 200) {
+    const response = await fetch(url);
+    if (response.status !== 200) {
       const errorData = await response.json();
       throw new Error(
         `HTTP ${errorData.statusCode} エラー\n${errorData.message}`

--- a/frontend/app/components/parts/trainingRecordTable/TrainingRecordTableByDate.tsx
+++ b/frontend/app/components/parts/trainingRecordTable/TrainingRecordTableByDate.tsx
@@ -6,7 +6,10 @@ type TrainingRecordProps = {
   date: string;
   trainingRecord: TrainingRecordWithName[];
   currentPage: number;
-  getTrainingRecord: (date: string) => Promise<
+  getTrainingRecord: (options?: {
+    exercise_id?: number;
+    date?: string;
+  }) => Promise<
     | {
         success: boolean;
         data: any;
@@ -38,7 +41,7 @@ const TrainingRecordTableByDate = ({
     const response = await trainingRecordDelete(id);
     if (response.success) {
       alert("削除が完了しました。");
-      const result = await getTrainingRecord(date);
+      const result = await getTrainingRecord({ date: date });
       if (result.success) {
         setTrainingRecord(result.data);
       }

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -12,6 +12,12 @@ export function Top() {
   const [date, setDate] = useState<Date | null>(new Date()); // 初期値は今日の日付
   const [holidays, setHolidays] = useState<Record<string, string>>({});
   const navigate = useNavigate();
+  // 筋トレ実施日を取得
+  // const uniqueDates = trainingRecords.map(
+  //   (record) => record.date.spilt("T")[0]
+  // );
+  // console.log("uniqueDates", uniqueDates);
+  // console.log("uniqueDates-type", typeof uniqueDates[0]);
 
   // APIから祝日データを取得
   useEffect(() => {

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -12,12 +12,6 @@ export function Top() {
   const [date, setDate] = useState<Date | null>(new Date()); // 初期値は今日の日付
   const [holidays, setHolidays] = useState<Record<string, string>>({});
   const navigate = useNavigate();
-  // 筋トレ実施日を取得
-  // const uniqueDates = trainingRecords.map(
-  //   (record) => record.date.spilt("T")[0]
-  // );
-  // console.log("uniqueDates", uniqueDates);
-  // console.log("uniqueDates-type", typeof uniqueDates[0]);
 
   // APIから祝日データを取得
   useEffect(() => {

--- a/frontend/app/pages/TrainingRecordListByDatePage.tsx
+++ b/frontend/app/pages/TrainingRecordListByDatePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
-import { getSelectDate } from "~/apiActions/TrainingRecord";
+import { getSelectDate, getTrainingRecord } from "~/apiActions/TrainingRecord";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
 import TrainingRecordTableByDate from "~/components/parts/trainingRecordTable/TrainingRecordTableByDate";
@@ -17,7 +17,7 @@ const TrainingRecordListByDatePage = () => {
   useEffect(() => {
     if (date != null) {
       (async () => {
-        const result = await getSelectDate(date);
+        const result = await getTrainingRecord({ date: date });
         if (result.success) {
           setTrainingRecords(result.data);
         } else {
@@ -38,7 +38,7 @@ const TrainingRecordListByDatePage = () => {
               date={date!}
               trainingRecord={trainingRecords}
               currentPage={currentPage}
-              getTrainingRecord={getSelectDate}
+              getTrainingRecord={getTrainingRecord}
               setTrainingRecord={setTrainingRecords}
               setCurrentPage={setCurrentPage}
             />

--- a/frontend/app/pages/TrainingRecordListPage.tsx
+++ b/frontend/app/pages/TrainingRecordListPage.tsx
@@ -57,7 +57,9 @@ const TrainingRecordListPage = () => {
 
   // 絞り込み表示処理呼び出し
   const handleGetSelectExerciseId = async () => {
-    const result = await getSelectExerciseId(trainingRecord.exercise_id);
+    const result = await getTrainingRecord({
+      exercise_id: trainingRecord.exercise_id,
+    });
     if (result.success) {
       setTrainingRecords(result.data);
       setCurrentPage(1);


### PR DESCRIPTION
# Why
- 複数ある筋トレ記録取得APIをクエリパラメータを使ってまとめる

# What
- [ ] findAllをロークエリからprismaのfindManyメソッドを使う形に修正
- [ ] フロントでapiを呼び出す処理も１つに修正
- [ ] 種目IDで絞り込むapiはクエリパラメータで文字列で送られてくるexercise_idを文字列に変換する