### PR TITLE
トップ画面をリファクタリング

### DIFF
--- a/frontend/app/hooks/useCalendar.ts
+++ b/frontend/app/hooks/useCalendar.ts
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useState } from "react";
+import { getHolidayList } from "~/apiActions/holidaysApi";
+import { getTrainingRecord } from "~/apiActions/TrainingRecord";
+import type { TrainingRecordWithName } from "~/type/training_record";
+
+// 日付を 'YYYY-MM-DD' 形式にフォーマットするヘルパー関数
+const formatDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const useCalendar = () => {
+  const [holidays, setHolidays] = useState<Record<string, string>>({});
+  // トレーニング実施日を'YYYY-MM-DD' 形式でsetオブジェクトの形で保持
+  const [trainingDates, setTrainingDates] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+
+  // データ取得
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const [holidayResult, trainingResult] = await Promise.all([
+          getHolidayList(),
+          getTrainingRecord(),
+        ]);
+
+        if (holidayResult.success) {
+          setHolidays(holidayResult.data);
+        }
+        if (trainingResult.success) {
+          const dates = trainingResult.data.map(
+            (record: TrainingRecordWithName) => record.date.slice(0, 10)
+          );
+          setTrainingDates(new Set(dates));
+        }
+      } catch (error) {
+        console.error("Failed to fetch calendar data", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  // useMemoを使って、計算結果をメモ化（パフォーマンス向上）
+  const tileClassName = useMemo(() => {
+    return ({ date, view }: { date: Date; view: string }) => {
+      if (view !== "month") return "";
+
+      const dateStr = formatDate(date);
+      const classes = [];
+
+      if (holidays[dateStr]) {
+        classes.push("holiday");
+      }
+      if (trainingDates.has(dateStr)) {
+        classes.push("is-training-record");
+      }
+      return classes.join(" ");
+    };
+  }, [holidays, trainingDates]);
+
+  return { loading, tileClassName, formatDate };
+};

--- a/frontend/app/hooks/useCalendar.ts
+++ b/frontend/app/hooks/useCalendar.ts
@@ -45,14 +45,17 @@ export const useCalendar = () => {
     fetchData();
   }, []);
 
-  // useMemoを使って、計算結果をメモ化（パフォーマンス向上）
+  // react-calendarの各日付に適用するCSSクラス名を返す関数を生成・メモ化
   const tileClassName = useMemo(() => {
+    // holidaysかtrainingDatesのどちらかが変更されたときのみ実行
     return ({ date, view }: { date: Date; view: string }) => {
+      // 現在の表示が月表示("month")でなければクラス名を付けず処理を終了
       if (view !== "month") return "";
 
+      // dateを"YYYY-MM-DD" 形式の文字列に変換
       const dateStr = formatDate(date);
+      // 祝日、トレーニング実施日に適用するCSSクラス名を格納するための空配列
       const classes = [];
-
       if (holidays[dateStr]) {
         classes.push("holiday");
       }
@@ -63,5 +66,6 @@ export const useCalendar = () => {
     };
   }, [holidays, trainingDates]);
 
+  // holidays,trainingDatesどちらもに変更がないときは前回生成した関数を利用
   return { loading, tileClassName, formatDate };
 };

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -1,83 +1,23 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import { useNavigate } from "react-router";
-import { getHolidayList } from "~/apiActions/holidaysApi";
-import { getSelectDate, getTrainingRecord } from "~/apiActions/TrainingRecord";
+import { getSelectDate } from "~/apiActions/TrainingRecord";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
-import type { TrainingRecordWithName } from "~/type/training_record";
+import { useCalendar } from "~/hooks/useCalendar";
 
 // トップページを生成する関数コンポーネント
 export function Top() {
-  const [date, setDate] = useState<Date | null>(new Date()); // 初期値は今日の日付
-  const [holidays, setHolidays] = useState<Record<string, string>>({});
-  const [dateAll, setDateAll] = useState<(string | null)[]>([]);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date()); // 初期値は今日の日付
   const navigate = useNavigate();
-
-  // 筋トレ実績がある日付を全件取得
-  useEffect(() => {
-    (async () => {
-      const result = await getTrainingRecord();
-      if (result.success) {
-        setDateAll(
-          result.data.map((record: TrainingRecordWithName) => record.date)
-        );
-      }
-    })();
-  }, []);
-
-  // APIから祝日データを取得
-  useEffect(() => {
-    (async () => {
-      const result = await getHolidayList();
-      if (result.success) {
-        setHolidays(result.data);
-      }
-    })();
-  }, []);
-
-  // 祝日かどうか判定
-  const isHoliday = (date: Date) => {
-    // Dateオブジェクトから「年」を取得
-    const year = date.getFullYear();
-    // Dateオブジェクトから「月」を2桁の文字列で取得
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    // Dateオブジェクトから「日」を2桁の文字列で取得
-    const day = String(date.getDate()).padStart(2, "0");
-    // 日本時間（JST）で「YYYY-MM-DD」形式の文字列を作成
-    const dateStr = `${year}-${month}-${day}`;
-    return dateStr in holidays;
-  };
-
-  // クリック時に日付を「yyyy-mm-dd」の形式で取得取得
-  const formatDate = (date: Date): string => {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}-${month}-${day}`;
-  };
-
-  // カレンダーの日付セルにクラスを付与
-  const tileClassName = ({ date, view }: { date: Date; view: string }) => {
-    if (view !== "month") return "";
-    const classes = [];
-    // 祝日判定
-    if (isHoliday(date)) {
-      classes.push("holiday");
-    }
-    // 筋トレ記録判定
-    const dateString = formatDate(date);
-    if (dateAll.some((date) => date && date.slice(0, 10) === dateString)) {
-      classes.push("is-training-record");
-    }
-    return classes.join(" ");
-  };
+  // ★ カスタムフックからロジックとデータを取得
+  const { loading, tileClassName, formatDate } = useCalendar();
 
   // 日付クリック時の処理
-  const handleClickDay = async (e: Date) => {
-    setDate(e); // 選択した日をハイライト
-    const formattedDate = formatDate(e);
+  const handleClickDay = async (date: Date) => {
+    setSelectedDate(date);
+    const formattedDate = formatDate(date);
     const result = await getSelectDate(formattedDate);
     const isTrainingRecord = result.data && result.data.length > 0;
     if (isTrainingRecord) {
@@ -88,6 +28,10 @@ export function Top() {
     }
   };
 
+  if (loading) {
+    return <div>Loading Calendar...</div>; // ローディング表示を追加
+  }
+
   return (
     <div className="layout">
       <Header />
@@ -96,7 +40,7 @@ export function Top() {
         <div className="content">
           <h1 className="page-title">筋トレ実績</h1>
           <Calendar
-            value={date}
+            value={selectedDate}
             onClickDay={handleClickDay}
             calendarType="gregory" // 日曜始り、土日休日とするためにグレゴリオ歴を指定
             locale="en-US" // 日付の「日」の表示を消すために、英語ロケールを使用

--- a/frontend/app/pages/Top.tsx
+++ b/frontend/app/pages/Top.tsx
@@ -1,4 +1,4 @@
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import { useNavigate } from "react-router";

--- a/frontend/app/type/training_record.ts
+++ b/frontend/app/type/training_record.ts
@@ -2,7 +2,7 @@
 // 他のトレーニング記録関連の型の拡張元として利用する
 export interface BaseTrainingRecord {
   id: number;
-  date: Date;
+  date: string;
   weight: number;
   count: number;
 }


### PR DESCRIPTION
# Why
- トップ画面をリファクタリング

# What
- [x] カレンダーの祝日、トレーニング実施日の表示を行う処理を分離
- [x] loadingを追加
- [x] useMemoを使い、不要な関数の再生成を防止
- [x] TrainingRecordのdateをDate型からstring型に変更