### PR TITLE
ログイン時のメッセージ表示をalertからMUIのDialogに変更

### DIFF
--- a/frontend/app/components/common/AlertDialog.tsx
+++ b/frontend/app/components/common/AlertDialog.tsx
@@ -1,0 +1,47 @@
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button,
+} from "@mui/material";
+
+type AlertDialogProps = {
+  dialog: {
+    open: boolean;
+    title: string;
+    message: string;
+  };
+  handleCloseDialog: () => Promise<void>;
+};
+
+const AlertDialog = (prop: AlertDialogProps) => {
+  const { dialog, handleCloseDialog } = prop;
+  return (
+    <Dialog
+      open={dialog.open} // stateに基づいて表示/非表示を制御
+      onClose={handleCloseDialog} // ダイアログの外側をクリックした時にも閉じる
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">{dialog.title}</DialogTitle>
+      <DialogContent>
+        {/* styleでメッセージ内の改行(\n)を<br/>に変換して表示 */}
+        <DialogContentText
+          id="alert-dialog-description"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
+          {dialog.message}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        {/* ボタンを押したらダイアログを閉じる(autoFocusによってEnterキーでOK) */}
+        <Button onClick={handleCloseDialog} autoFocus>
+          OK
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+export default AlertDialog;

--- a/frontend/app/pages/LogInPage.tsx
+++ b/frontend/app/pages/LogInPage.tsx
@@ -50,7 +50,7 @@ const LoginPage = () => {
       setDialog({
         open: true,
         title: "エラー",
-        message: "ログインに失敗しました。",
+        message: response.error,
       });
     }
   };

--- a/frontend/app/pages/LogInPage.tsx
+++ b/frontend/app/pages/LogInPage.tsx
@@ -1,15 +1,8 @@
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Button as ButtonByMui,
-} from "@mui/material";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { authLogIn } from "~/apiActions/logInApi";
 import { useAuth } from "~/auth/AuthContext";
+import AlertDialog from "~/components/common/AlertDialog";
 import Header from "~/components/common/Header";
 import Button from "~/components/parts/Button";
 import InputField from "~/components/parts/form/InputField";
@@ -103,29 +96,7 @@ const LoginPage = () => {
               hoverBackground="white"
             />
           </form>
-          <Dialog
-            open={dialog.open} // stateに基づいて表示/非表示を制御
-            onClose={handleCloseDialog} // ダイアログの外側をクリックした時にも閉じる
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
-          >
-            <DialogTitle id="alert-dialog-title">{dialog.title}</DialogTitle>
-            <DialogContent>
-              {/* styleでメッセージ内の改行(\n)を<br/>に変換して表示 */}
-              <DialogContentText
-                id="alert-dialog-description"
-                style={{ whiteSpace: "pre-wrap" }}
-              >
-                {dialog.message}
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              {/* ボタンを押したらダイアログを閉じる(autoFocusによってEnterキーでOK) */}
-              <ButtonByMui onClick={handleCloseDialog} autoFocus>
-                OK
-              </ButtonByMui>
-            </DialogActions>
-          </Dialog>
+          <AlertDialog dialog={dialog} handleCloseDialog={handleCloseDialog} />
         </div>
       </div>
     </div>

--- a/frontend/app/pages/LogInPage.tsx
+++ b/frontend/app/pages/LogInPage.tsx
@@ -1,3 +1,11 @@
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button as ButtonByMui,
+} from "@mui/material";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { authLogIn } from "~/apiActions/logInApi";
@@ -11,6 +19,12 @@ const LoginPage = () => {
   const [loginFormData, setLoginFormData] = useState<LoginForm>({
     userId: "",
     password: "",
+  });
+  // ダイアログの状態を管理
+  const [dialog, setDialog] = useState({
+    open: false,
+    title: "",
+    message: "",
   });
   const navigate = useNavigate();
   const { user, login } = useAuth();
@@ -31,11 +45,31 @@ const LoginPage = () => {
     const response = await authLogIn(loginFormData);
     if (response.success) {
       localStorage.setItem("access_token", response.data.access_token);
-      alert("ログインに成功しました。");
-      // loginの完了をawaitしてから画面遷移
-      await login(response.data.access_token);
+
+      // 成功ダイアログを表示するstateを更新
+      setDialog({
+        open: true,
+        title: "成功",
+        message: "ログインに成功しました。",
+      });
     } else {
-      alert(`ログインに失敗しました。\n\n${response.error}`);
+      // エラーダイアログを表示するstateを更新
+      setDialog({
+        open: true,
+        title: "エラー",
+        message: "ログインに失敗しました。",
+      });
+    }
+  };
+
+  const handleCloseDialog = async () => {
+    setDialog({ ...dialog, open: false });
+
+    if (dialog.title === "成功") {
+      const token = localStorage.getItem("access_token");
+      if (token) {
+        await login(token);
+      }
     }
   };
 
@@ -69,6 +103,29 @@ const LoginPage = () => {
               hoverBackground="white"
             />
           </form>
+          <Dialog
+            open={dialog.open} // stateに基づいて表示/非表示を制御
+            onClose={handleCloseDialog} // ダイアログの外側をクリックした時にも閉じるように
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+          >
+            <DialogTitle id="alert-dialog-title">{dialog.title}</DialogTitle>
+            <DialogContent>
+              {/* メッセージ内の改行(\n)を<br/>に変換して表示 */}
+              <DialogContentText
+                id="alert-dialog-description"
+                style={{ whiteSpace: "pre-wrap" }}
+              >
+                {dialog.message}
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              {/* ボタンを押したらダイアログを閉じる */}
+              <ButtonByMui onClick={handleCloseDialog} autoFocus>
+                OK
+              </ButtonByMui>
+            </DialogActions>
+          </Dialog>
         </div>
       </div>
     </div>

--- a/frontend/app/pages/LogInPage.tsx
+++ b/frontend/app/pages/LogInPage.tsx
@@ -105,13 +105,13 @@ const LoginPage = () => {
           </form>
           <Dialog
             open={dialog.open} // stateに基づいて表示/非表示を制御
-            onClose={handleCloseDialog} // ダイアログの外側をクリックした時にも閉じるように
+            onClose={handleCloseDialog} // ダイアログの外側をクリックした時にも閉じる
             aria-labelledby="alert-dialog-title"
             aria-describedby="alert-dialog-description"
           >
             <DialogTitle id="alert-dialog-title">{dialog.title}</DialogTitle>
             <DialogContent>
-              {/* メッセージ内の改行(\n)を<br/>に変換して表示 */}
+              {/* styleでメッセージ内の改行(\n)を<br/>に変換して表示 */}
               <DialogContentText
                 id="alert-dialog-description"
                 style={{ whiteSpace: "pre-wrap" }}
@@ -120,7 +120,7 @@ const LoginPage = () => {
               </DialogContentText>
             </DialogContent>
             <DialogActions>
-              {/* ボタンを押したらダイアログを閉じる */}
+              {/* ボタンを押したらダイアログを閉じる(autoFocusによってEnterキーでOK) */}
               <ButtonByMui onClick={handleCloseDialog} autoFocus>
                 OK
               </ButtonByMui>


### PR DESCRIPTION
# Why
ログイン成功/失敗時のメッセージ表示をalertで行っていたが、以下の課題があった。
- Webアプリ全体の画面との統一感がなく見た目が良くない
- メッセージ表示にalertを用いるのはベストプラクティスではない

UIの見た目を良くし、ユーザー体験を向上させるためMUIコンポーネントを用いてdialogに変更する。

# What
- `AlertDialog`コンポーネント作成
 - [x] `app/components/common/`に`タイトル、メッセージ、ダイアログを閉じるハンドラーをpropsで受け取るAlertDialog.tsxを作成
- LogInPage.tsxのリファクタリング
 - [x] `alert()`を削除し、ダイアログの表示状態を管理するための`state`を追加
 - [x] APIレスポンスに応じて、`state`を更新し、`AlertDialog`コンポーネントを呼び出すように変更
 - [x] `login()`関数の実行タイミングをalertを閉じた後からダイアログを閉じた後に変更
 ※サーバーからユーザー情報を取得し、その情報でアプリケーションの認証状態(`app/auth/AuthContext.tsx`の`user`)を更新する