### PR TITLE
feat: カレントユーザーのデータのみでトレーニング記録を表示

### DIFF
--- a/backend/src/training-record/training_record.controller.ts
+++ b/backend/src/training-record/training_record.controller.ts
@@ -22,8 +22,14 @@ export class TrainingRecordController {
   constructor(private readonly trainingRecordService: TrainingRecordService) {}
 
   @Get()
-  async findAll(@Query() trainingRecordDto: TrainingRecordDto) {
-    return await this.trainingRecordService.findAll(trainingRecordDto);
+  async findAll(
+    @Query() trainingRecordDto: TrainingRecordDto,
+    @Req() req: any,
+  ) {
+    return await this.trainingRecordService.findAll(
+      trainingRecordDto,
+      req.user.id,
+    );
   }
 
   @Get(':id')

--- a/backend/src/training-record/training_record.controller.ts
+++ b/backend/src/training-record/training_record.controller.ts
@@ -33,8 +33,8 @@ export class TrainingRecordController {
   }
 
   @Get(':id')
-  async findById(@Param('id', ParseIntPipe) id: number) {
-    return await this.trainingRecordService.findById(id);
+  async findById(@Param('id', ParseIntPipe) id: number, @Req() req: any) {
+    return await this.trainingRecordService.findById(id, req.user.id);
   }
 
   @Post()

--- a/backend/src/training-record/training_record.controller.ts
+++ b/backend/src/training-record/training_record.controller.ts
@@ -52,8 +52,13 @@ export class TrainingRecordController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() createTrainingRecordDto: CreateTrainingRecordDto,
+    @Req() req: any,
   ) {
-    return await this.trainingRecordService.update(id, createTrainingRecordDto);
+    return await this.trainingRecordService.update(
+      id,
+      createTrainingRecordDto,
+      req.user.id,
+    );
   }
 
   @Delete(':id')

--- a/backend/src/training-record/training_record.controller.ts
+++ b/backend/src/training-record/training_record.controller.ts
@@ -57,7 +57,7 @@ export class TrainingRecordController {
   }
 
   @Delete(':id')
-  async delete(@Param('id', ParseIntPipe) id: number) {
-    return await this.trainingRecordService.delete(id);
+  async delete(@Param('id', ParseIntPipe) id: number, @Req() req: any) {
+    return await this.trainingRecordService.delete(id, req.user.id);
   }
 }

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -8,7 +8,7 @@ import { TrainingRecordDto } from './dto/get-training-record.dto';
 export class TrainingRecordService {
   constructor(private prisma: PrismaService) {}
 
-  async findAll(trainingRecordDto: TrainingRecordDto) {
+  async findAll(trainingRecordDto: TrainingRecordDto, userId: number) {
     // dto取り出し
     const exercise_id = trainingRecordDto.exercise_id;
     const date = trainingRecordDto.date;
@@ -23,7 +23,7 @@ export class TrainingRecordService {
     }
 
     const response = await this.prisma.trainingRecord.findMany({
-      where,
+      where: { userId },
       include: {
         exerciseCategories: {
           select: {

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -14,7 +14,7 @@ export class TrainingRecordService {
     const date = trainingRecordDto.date;
 
     // where条件の組み立て
-    const where: any = {};
+    const where: any = { userId: userId };
     if (exercise_id !== undefined) {
       where.exerciseId = exercise_id;
     }
@@ -23,7 +23,7 @@ export class TrainingRecordService {
     }
 
     const response = await this.prisma.trainingRecord.findMany({
-      where: { userId },
+      where: where,
       include: {
         exerciseCategories: {
           select: {
@@ -113,9 +113,8 @@ export class TrainingRecordService {
   }
 
   async delete(id: number) {
-    await this.prisma.$executeRaw`
-    DELETE FROM training_records WHERE id = ${id};
-    `;
-    return;
+    await this.prisma.trainingRecord.delete({
+      where: { id: id },
+    });
   }
 }

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { CreateTrainingRecordDto } from './dto/create-training-record.dto';
 import { PrismaService } from 'src/prisma.service';
 import { formatInTimeZone } from 'date-fns-tz';
@@ -112,7 +112,14 @@ export class TrainingRecordService {
     return updateResult;
   }
 
-  async delete(id: number) {
+  async delete(id: number, userId: number) {
+    const record = await this.prisma.trainingRecord.findUnique({
+      where: { id: id },
+    });
+
+    if (!record || record.userId !== userId) {
+      throw new ForbiddenException('この操作を行う権限がありません。');
+    }
     await this.prisma.trainingRecord.delete({
       where: { id: id },
     });

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -1,4 +1,8 @@
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateTrainingRecordDto } from './dto/create-training-record.dto';
 import { PrismaService } from 'src/prisma.service';
 import { formatInTimeZone } from 'date-fns-tz';
@@ -46,9 +50,9 @@ export class TrainingRecordService {
     return result;
   }
 
-  async findById(id: number) {
+  async findById(id: number, userId: number) {
     const response = await this.prisma.trainingRecord.findUnique({
-      where: { id },
+      where: { id: id, userId: userId },
       include: {
         exerciseCategories: {
           select: {
@@ -57,7 +61,11 @@ export class TrainingRecordService {
         },
       },
     });
-    if (!response) return null;
+    if (!response) {
+      throw new NotFoundException(
+        `ID: ${id} の記録が見つからないか、アクセス権がありません。`,
+      );
+    }
     const result = {
       id: response.id,
       target_id: response.exerciseCategories?.targetId,

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -106,20 +106,16 @@ export class TrainingRecordService {
     if (!record || record.userId !== userId) {
       throw new ForbiddenException('この操作を行う権限がありません。');
     }
-    const currentJstTime = formatInTimeZone(
-      new Date(),
-      'Asia/Tokyo',
-      'yyyy-MM-dd HH:mm:ss.sss',
-    );
-    const updateResult = await this.prisma.$executeRaw`
-      UPDATE training_records SET
-      exercise_id = ${createTrainingRecordDto.exercise_id},
-      date = ${new Date(createTrainingRecordDto.date)},
-      weight =${createTrainingRecordDto.weight},
-      count = ${createTrainingRecordDto.count},
-      update_date = ${currentJstTime}::timestamp
-      WHERE id = ${id};
-    `;
+
+    const updateResult = await this.prisma.trainingRecord.update({
+      where: { id: id },
+      data: {
+        exerciseId: createTrainingRecordDto.exercise_id,
+        date: new Date(createTrainingRecordDto.date),
+        weight: createTrainingRecordDto.weight,
+        count: createTrainingRecordDto.count,
+      },
+    });
     return updateResult;
   }
 

--- a/backend/src/training-record/training_record.service.ts
+++ b/backend/src/training-record/training_record.service.ts
@@ -94,7 +94,18 @@ export class TrainingRecordService {
     return training;
   }
 
-  async update(id: number, createTrainingRecordDto: CreateTrainingRecordDto) {
+  async update(
+    id: number,
+    createTrainingRecordDto: CreateTrainingRecordDto,
+    userId: number,
+  ) {
+    const record = await this.prisma.trainingRecord.findUnique({
+      where: { id: id },
+    });
+
+    if (!record || record.userId !== userId) {
+      throw new ForbiddenException('この操作を行う権限がありません。');
+    }
     const currentJstTime = formatInTimeZone(
       new Date(),
       'Asia/Tokyo',


### PR DESCRIPTION
## Why（背景）
現在、トレーニング記録が全ユーザーで共通して表示されてしまっており、パーソナルな記録アプリとして機能していないため、以下の機能を追加する。
- トレーニング記録はユーザーに紐付け、ログインユーザーごとにトレーニング記録を表示する。
- 上記の実施に合わせて、現在認証ユーザーであれば、カレントユーザー以外のデータ操作も行えてしまう問題を解消する。

## What（tasks）
- **データベーススキーマ修正 (`schema.prisma`)**
  - `User`モデルと`TrainingRecord`モデル間にリレーションを設定する。 #55 で対応済み
  - `User`モデルと`ExerciseCategory`モデル間にリレーションを設定する。#55 で対応済み
- **バックエンドAPI修正**
  - トレーニング記録の作成(`Create`)時、リクエストユーザーのIDを保存するようにする。#55 で対応済み
  - トレーニング記録の読み取り(`Read`)時、リクエストユーザーのIDでデータを絞り込むようにする。
  - トレーニング記録更新(`Update`)・削除(`Delete`)時も、本人しか操作できないように権限チェックを追加する。
  - 個別トレーニング記録読み取り(`Read`)時も、本人しか操作できないように権限チェックを追加する。
  
  ## チェックリスト
  - **データベーススキーマ修正 (`schema.prisma`)**
    - 該当なし
  - **バックエンドAPI修正**
    - training_record.controller.tsにおいて以下を実施した。
      - [x] findAllメソッドの引数にリクエストオブジェクトとしてユーザIDを追加
      - [x] updateメソッドの引数にリクエストオブジェクトとしてユーザIDを追加
      - [x] deleteメソッドの引数にリクエストオブジェクトとしてユーザIDを追加
      - [x] findByIdメソッドの引数にリクエストオブジェクトとしてユーザIDを追加

    - training_record.service.tsにおいて以下を実施した。
      - [x] ロークエリをPrisma Clientのupdateメソッドに書き換え
      - [x] Prisma ClientのupdateメソッドでuserIdによる絞り込みを追加
      - [x] ロークエリをPrisma Clientのdeleteメソッドに書き換え
      - [x] Prisma ClientのdeleteメソッドでuserIdによる絞り込みを追加
      - [x] Prisma ClientのfindUniqueメソッドでuserIdによる絞り込みを追加