### PR TITLE
fix: docker-compose.yamlからversionを削除

### DIFF
--- a/db/docker-compose.yaml
+++ b/db/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:14


### PR DESCRIPTION
docker-compose up -d実行時、versionでエラーが生じていたため、
docker-compose.yamlからversionを削除