### PR TITLE
refactor: ログイン画面のヘッダーにサインアップボタンを表示  #52

### DIFF
--- a/frontend/app/components/common/Header.tsx
+++ b/frontend/app/components/common/Header.tsx
@@ -43,21 +43,25 @@ const Header = () => {
         className="header-right"
         style={{ display: "flex", alignItems: "center", gap: "0.5em" }}
       >
+        {/* 未サインイン状態時にサインアップボタンを表示 */}
+        {!user && (
+          <div>
+            <TooltipIconButton
+              tooltipTitle="サインアップ"
+              iconButtonBackgroundColor="white"
+              iconButtonColor="gray"
+              iconButtonHoverBackgroundColor="gray"
+              iconButtonHoverColor="white"
+              onClick={handleSingUp}
+              IconComponent={PersonAddIcon}
+            />
+          </div>
+        )}
+        {/* サインイン状態時にログインユーザーのニックネームとサインアウトボタンを表示 */}
         {user && (
           <>
             <div>
               <span>ログインユーザー：{user.username}</span>
-            </div>
-            <div>
-              <TooltipIconButton
-                tooltipTitle="サインアップ"
-                iconButtonBackgroundColor="white"
-                iconButtonColor="gray"
-                iconButtonHoverBackgroundColor="gray"
-                iconButtonHoverColor="white"
-                onClick={handleSingUp}
-                IconComponent={PersonAddIcon}
-              />
             </div>
             <div>
               <TooltipIconButton


### PR DESCRIPTION
Close #52

## Why（背景）
- 現在、ログインしていないとサインアップ画面に遷移するためのボタンが表示されないようになっている。
- そのため初めてアプリを利用する人がログインできない状態にある。

## What（タスク）
- [x] サインアップ画面へ遷移するためのボタンはログイン画面内に表示する。

## チェックリスト
- [x] サインインページのヘッダーにサインアップボタンを追加
- [x] ログイン成功後のヘッダーからサインアップボタンを削除 