### PR TITLE
Feature/backend/add friendship model

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -121,13 +121,23 @@ Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
 npx prisma format
 ```
 
-3. マイグレーションファイルを作成
+3. 生成されるSQLクエリを確認
+
+```cmd
+npx prisma migrate diff --from-migrations prisma --to-schema-datasource --script
+```
+
+`--from-migrations prisma` 現在のマイグレーション履歴を基に差分を計算  
+`--to-schema-datasource` Prismaスキーマを基に差分を計算  
+`--script` 生成されるSQLを標準出力に表示
+
+4. マイグレーションファイルを作成
 
 ```cmd
 npx prisma migrate dev --name <修正内容を記述>
 ```
 
-4. prisma client も再生成
+5. prisma client も再生成
 
 ```cmd
 npx prisma generate

--- a/backend/README.md
+++ b/backend/README.md
@@ -124,7 +124,7 @@ npx prisma format
 3. 生成されるSQLクエリを確認
 
 ```cmd
-px prisma migrate diff --from-migrations ./prisma/migrations --to-schema-datamodel ./prisma/schema.prisma --shadow-database-url "$DATABASE_URL" --script
+npx prisma migrate diff --from-migrations ./prisma/migrations --to-schema-datamodel ./prisma/schema.prisma --shadow-database-url "$DATABASE_URL" --script
 ```
 
 `--from-migrations ./prisma/migrations` 現在のマイグレーション履歴を基に差分を計算  

--- a/backend/README.md
+++ b/backend/README.md
@@ -124,11 +124,12 @@ npx prisma format
 3. 生成されるSQLクエリを確認
 
 ```cmd
-npx prisma migrate diff --from-migrations prisma --to-schema-datasource --script
+px prisma migrate diff --from-migrations ./prisma/migrations --to-schema-datamodel ./prisma/schema.prisma --shadow-database-url "$DATABASE_URL" --script
 ```
 
-`--from-migrations prisma` 現在のマイグレーション履歴を基に差分を計算  
-`--to-schema-datasource` Prismaスキーマを基に差分を計算  
+`--from-migrations ./prisma/migrations` 現在のマイグレーション履歴を基に差分を計算  
+`--to-schema-datamodel ./prisma/schema.prisma` Prismaスキーマを基に差分を計算  
+`--shadow-database-url "$DATABASE_URL"` --from-migrations を使用する際に、Prismaがマイグレーション履歴からデータベースの状態を一時的に再現するために使用するシャドウデータベースの接続URL。(**$DATABASE_URL**は.envを参照)  
 `--script` 生成されるSQLを標準出力に表示
 
 4. マイグレーションファイルを作成

--- a/backend/prisma/migrations/20250726075812_add_friendship_table/migration.sql
+++ b/backend/prisma/migrations/20250726075812_add_friendship_table/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "FriendshipStatus" AS ENUM ('PENDING', 'ACCEPTED', 'DECLINED');
+
+-- CreateTable
+CREATE TABLE "friendships" (
+    "requester_user_id" INTEGER NOT NULL,
+    "approval_user_id" INTEGER NOT NULL,
+    "status" "FriendshipStatus" NOT NULL,
+    "create_date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "friendships_requester_user_id_approval_user_id_key" ON "friendships"("requester_user_id", "approval_user_id");
+
+-- AddForeignKey
+ALTER TABLE "friendships" ADD CONSTRAINT "friendships_requester_user_id_fkey" FOREIGN KEY ("requester_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "friendships" ADD CONSTRAINT "friendships_approval_user_id_fkey" FOREIGN KEY ("approval_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250726081147_add_friendship_table/migration.sql
+++ b/backend/prisma/migrations/20250726081147_add_friendship_table/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - Changed the type of `status` on the `friendships` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "friendships" DROP COLUMN "status",
+ADD COLUMN     "status" INTEGER NOT NULL;
+
+-- DropEnum
+DROP TYPE "FriendshipStatus";
+
+-- CreateTable
+CREATE TABLE "ApprovalFriendStatus" (
+    "id" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "ApprovalFriendStatus_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "friendships" ADD CONSTRAINT "friendships_status_fkey" FOREIGN KEY ("status") REFERENCES "ApprovalFriendStatus"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250726100632_add_colmun_id_surrogate_key_to_friendship/migration.sql
+++ b/backend/prisma/migrations/20250726100632_add_colmun_id_surrogate_key_to_friendship/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "friendships" ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "friendships_pkey" PRIMARY KEY ("id");

--- a/backend/prisma/migrations/20250726102446_rename_approvalfriendstatusetable/migration.sql
+++ b/backend/prisma/migrations/20250726102446_rename_approvalfriendstatusetable/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - You are about to drop the `ApprovalFriendStatus` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "friendships" DROP CONSTRAINT "friendships_status_fkey";
+
+-- DropTable
+DROP TABLE "ApprovalFriendStatus";
+
+-- CreateTable
+CREATE TABLE "approval_friend_statuses" (
+    "id" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "approval_friend_statuses_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "friendships" ADD CONSTRAINT "friendships_status_fkey" FOREIGN KEY ("status") REFERENCES "approval_friend_statuses"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -81,6 +81,9 @@ model User {
 }
 
 model Friendship {
+  // requesterUserIdとapprovalUserIdが複合種キーとなるが、
+  // パフォーマンス性とシンプルさを保つためにサロゲートキーを用いる
+  id                   Int                  @id @default(autoincrement())
   requesterUserId      Int                  @map("requester_user_id")
   // Userテーブルの中間テーブルとなるようにリレーションを定義
   requester            User                 @relation("Requester", fields: [requesterUserId], references: [id])

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -88,7 +88,7 @@ model Friendship {
   // Userテーブルの中間テーブルとなるようにリレーションを定義
   approver             User                 @relation("Approver", fields: [approvalUserId], references: [id])
   status               Int
-  // ApprovalFriendStatusテーブルの中間テーブルとなるようにリレーションを定義
+  // FriendshipテーブルからApprovalFriendStatusテーブルへのリレーションを定義(多 対 1： ApprovalFriendStatus 対 Friendship)
   approvalFriendStatus ApprovalFriendStatus @relation(fields: [status], references: [id])
   createDate           DateTime             @default(now()) @map("create_date")
   updateDate           DateTime             @default(now()) @updatedAt @map("update_date")

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -88,10 +88,19 @@ model Friendship {
   // Userテーブルの中間テーブルとなるようにリレーションを定義
   approver             User                 @relation("Approver", fields: [approvalUserId], references: [id])
   status               Int
+  // ApprovalFriendStatusテーブルの中間テーブルとなるようにリレーションを定義
+  approvalFriendStatus ApprovalFriendStatus @relation(fields: [status], references: [id])
   createDate           DateTime             @default(now()) @map("create_date")
   updateDate           DateTime             @default(now()) @updatedAt @map("update_date")
 
   // 同じユーザー間の申請が重複しないようにユニーク制約を追加
   @@unique([requesterUserId, approvalUserId])
   @@map("friendships")
+}
+
+model ApprovalFriendStatus {
+  id   Int    @id
+  name String
+
+  friendships Friendship[]
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -106,4 +106,6 @@ model ApprovalFriendStatus {
   name String
 
   friendships Friendship[]
+
+  @@map("approval_friend_statuses")
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -74,5 +74,24 @@ model User {
   // UserからTrainingRecordへのリレーションを定義(１ 対 多： User 対 TrainingRecord)
   trainingRecords TrainingRecord[]
 
+  requesters Friendship[] @relation("Requester")
+  approvers  Friendship[] @relation("Approver")
+
   @@map("users")
+}
+
+model Friendship {
+  requesterUserId      Int                  @map("requester_user_id")
+  // Userテーブルの中間テーブルとなるようにリレーションを定義
+  requester            User                 @relation("Requester", fields: [requesterUserId], references: [id])
+  approvalUserId       Int                  @map("approval_user_id")
+  // Userテーブルの中間テーブルとなるようにリレーションを定義
+  approver             User                 @relation("Approver", fields: [approvalUserId], references: [id])
+  status               Int
+  createDate           DateTime             @default(now()) @map("create_date")
+  updateDate           DateTime             @default(now()) @updatedAt @map("update_date")
+
+  // 同じユーザー間の申請が重複しないようにユニーク制約を追加
+  @@unique([requesterUserId, approvalUserId])
+  @@map("friendships")
 }


### PR DESCRIPTION
Parent issue: #60

## 仕様
- テーブル定義追加 
  -**モデル名**`Friendship` フレンドシップ
    - **カラム**
      -`id`  id Int型 
      - `requesterId` 申請者ID Int型
      - `apploverId` 承認者ID Int型
      - `status` 申請状況 Enum型 (`PENDING`, `ACCEPTED`, `DECLINED`のいずれか)
      - `createdAt`  作成日時 DateTime型
      - `updatedAt`  更新日時 DateTime型
   - **制約**
      - `requesterId`と`apploverId`の組み合わせはユニーク（重複不可）
   - **リレーション**
      - UserモデルのidとFrendshipモデルのrequesterIdが関連を持つ
      - UserモデルのidとFrendshipモデルのapploverIdが関連を持つ

## チェックリスト
- [x] `schema.prisma`に`Friendship`モデルと関連リレーションが追加されている
- [x] `schema.prisma`に`ApprovalFriendStatus`モデルと関連のリレーションが追加されている
- [x] `migration`ファイルが作成されていること
- [x] DBに `friendships`テーブルと`approval_friend_statuses`テーブルが作成されていること(pgAdminで確認)
