### PR TITLE
feat: ユーザー検索API追加  #62

### DIFF
--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -6,10 +6,14 @@ import {
   Param,
   Delete,
   Get,
+  Query,
+  Req,
+  UseGuards,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @Controller('user')
 export class UserController {
@@ -23,6 +27,13 @@ export class UserController {
   @Get()
   findAll() {
     return this.userService.findAll();
+  }
+
+  @UseGuards(AuthGuard)
+  @Get('search')
+  async searchUsers(@Query('q') query: string, @Req() req: any) {
+    const currentUserId = req.user.id;
+    return this.userService.searchUsersByQuery(query, currentUserId);
   }
 
   @Get(':id')

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -50,6 +50,44 @@ export class UserService {
     return selectUser;
   }
 
+  async searchUsersByQuery(query: string, currentUserId: number) {
+    if (!query) {
+      return []; // クエリが未指定の場合、検索は行わない(空配列を返す)
+    }
+
+    const users = await this.prisma.user.findMany({
+      where: {
+        AND: [
+          // AND条件その１: 以下のOR条件
+          {
+            OR: [
+              // OR条件その１: ユーザーIDがクエリと完全一致する
+              {
+                userId: { equals: query },
+              },
+              // OR条件その２: ニックネームがクエリを部分一致で含む(ただし、大文字小文字の区別なし)
+              {
+                username: { contains: query, mode: 'insensitive' },
+              },
+            ],
+          },
+          // AND条件その２: ログインユーザーは検索結果から除外する
+          {
+            id: { not: currentUserId },
+          },
+        ],
+      },
+
+      select: {
+        id: true,
+        userId: true,
+        username: true,
+      },
+    });
+
+    return users;
+  }
+
   async findOne(id: number) {
     const user = await this.prisma.user.findUnique({
       select: {


### PR DESCRIPTION
## Why(背景)
Parent issue: #60
フレンド申請を行う準備として、ユーザー検索APIが必要となった。

## What(タスク)
  - userエンティティにユーザー検索APIを追加
    - `GET /users/search?q={query}`
    - `query`（ユーザーID(完全一致)またはニックネーム(部分一致)）にするユーザーを検索する。
    - ユーザーオブジェクトの配列 `[{ id, username, userId }]`を返す。
    - ただし、自分自身は検索結果から除外する。

## チェックリスト
- [x] ユーザー検索API (`GET /users/search`) が追加されている