### PR TITLE
feat: フレンド申請一覧取得API実装

### DIFF
--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -14,7 +14,7 @@ export class FriendshipController {
   }
 
   @Get('requests/received')
-  async findByAllPendingUser(@Req() req: any) {
+  async findReceivedRequests(@Req() req: any) {
     return await this.friendshipService.findByAllPendingUser(req.user.id);
   }
 }

--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -14,7 +14,7 @@ export class FriendshipController {
   }
 
   @Get('requests/received')
-  async findByAllPendingUser() {
-    return await this.friendshipService.findByAllPendingUser();
+  async findByAllPendingUser(@Req() req: any) {
+    return await this.friendshipService.findByAllPendingUser(req.user.id);
   }
 }

--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -15,6 +15,6 @@ export class FriendshipController {
 
   @Get('requests/received')
   async findReceivedRequests(@Req() req: any) {
-    return await this.friendshipService.findByAllPendingUser(req.user.id);
+    return await this.friendshipService.findReceivedRequests(req.user.id);
   }
 }

--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, UseGuards, Req } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Req, Get } from '@nestjs/common';
 import { FriendshipService } from './friendship.service';
 import { CreateFriendshipDto } from './dto/create-friendship.dto';
 import { AuthGuard } from 'src/auth/auth.guard';
@@ -11,5 +11,10 @@ export class FriendshipController {
   @Post('requests')
   create(@Body() createFriendshipDto: CreateFriendshipDto, @Req() req: any) {
     return this.friendshipService.create(createFriendshipDto, req.user.id);
+  }
+
+  @Get('requests/received')
+  async findByAllPendingUser() {
+    return await this.friendshipService.findByAllPendingUser();
   }
 }

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -47,7 +47,16 @@ export class FriendshipService {
     const requestUser = await this.prisma.friendship.findMany({
       where: {
         approvalUserId: userId,
-        status: 0,
+        approvalFriendStatus: {
+          name: 'PENDING',
+        },
+      },
+      include: {
+        approvalFriendStatus: {
+          select: {
+            name: true,
+          },
+        },
       },
     });
     return requestUser;

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -52,6 +52,13 @@ export class FriendshipService {
         },
       },
       include: {
+        // requesterUserIdが参照するuserモデルにアクセスし、idとニックネームを結果に追加
+        requester: {
+          select: {
+            id: true,
+            username: true,
+          },
+        },
         approvalFriendStatus: {
           select: {
             name: true,

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -25,7 +25,7 @@ export class FriendshipService {
       where: {
         OR: [
           { requesterUserId: requesterUserId, approvalUserId: approvalUserId },
-          { requesterUserId: approvalUserId, approvalUserId: requesterUserId }, // 逆方向の申請もチェック
+          { status: 1 },
         ],
       },
     });

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -58,6 +58,9 @@ export class FriendshipService {
           },
         },
       },
+      orderBy: {
+        createDate: 'desc',
+      },
     });
     return requestUser;
   }

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -43,7 +43,7 @@ export class FriendshipService {
     return friendRequest;
   }
 
-  async findByAllPendingUser(userId: number) {
+  async findReceivedRequests(userId: number) {
     const requestUser = await this.prisma.friendship.findMany({
       where: {
         approvalUserId: userId,

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -42,4 +42,14 @@ export class FriendshipService {
     });
     return friendRequest;
   }
+
+  async findByAllPendingUser(userId: number) {
+    const requestUser = await this.prisma.friendship.findMany({
+      where: {
+        approvalUserId: userId,
+        status: 0,
+      },
+    });
+    return requestUser;
+  }
 }


### PR DESCRIPTION
## Why(背景)
Parent issue: #60
フレンド申請を行う準備として、フレンド申請一覧取得APIが必要となった。

## 仕様
  - **フレンド申請一覧取得**
    - `GET /friends/requests/received`
    - **機能**: 自分宛に届いている、保留中(`PENDING`)のフレンド申請を一覧で取得する。
    - **レスポンス**: `Friendship`オブジェクトの配列。申請者のユーザー情報(`requester: { id, username }`)も`include`して返す。

## チェックリスト
- [x] フレンド申請一覧取得API(`GET /friends/requests/received`)を実装する