### PR TITLE
feat: フレンド申請承認/拒否API実装

### DIFF
--- a/backend/src/friendship/dto/update-friendship.dto.ts
+++ b/backend/src/friendship/dto/update-friendship.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt, IsNotEmpty, IsIn } from 'class-validator';
+
+export class UpdateFriendshipDto {
+  @IsInt()
+  @IsNotEmpty()
+  // statusに指定できる数値を、[1, 2] に限定する
+  @IsIn([1, 2])
+  status: number;
+}

--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -1,7 +1,18 @@
-import { Controller, Post, Body, UseGuards, Req, Get } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  Req,
+  Get,
+  Patch,
+  ParseIntPipe,
+  Param,
+} from '@nestjs/common';
 import { FriendshipService } from './friendship.service';
 import { CreateFriendshipDto } from './dto/create-friendship.dto';
 import { AuthGuard } from 'src/auth/auth.guard';
+import { UpdateFriendshipDto } from './dto/update-friendship.dto';
 
 @Controller('friendship')
 @UseGuards(AuthGuard)
@@ -16,5 +27,18 @@ export class FriendshipController {
   @Get('requests/received')
   async findReceivedRequests(@Req() req: any) {
     return await this.friendshipService.findReceivedRequests(req.user.id);
+  }
+
+  @Patch(':friendshipId')
+  async update(
+    @Param('friendshipId', ParseIntPipe) friendshipId: number,
+    @Body() updateFriendshipDto: UpdateFriendshipDto,
+    @Req() req: any,
+  ) {
+    return await this.friendshipService.updateRequestStatus(
+      friendshipId,
+      updateFriendshipDto.status,
+      req.user.id,
+    );
   }
 }

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
 } from '@nestjs/common';
 import { CreateFriendshipDto } from './dto/create-friendship.dto';
@@ -70,5 +71,38 @@ export class FriendshipService {
       },
     });
     return requestUser;
+  }
+
+  async updateRequestStatus(
+    friendshipId: number,
+    newStatus: number,
+    currentUserId: number,
+  ) {
+    // 1. まず、更新対象のFriendshipレコードを取得する
+    const friendship = await this.prisma.friendship.findUnique({
+      where: { id: friendshipId },
+    });
+
+    // 2. 権限チェック
+    //    - レコードが存在しない
+    //    - または、自分が申請された側(requesterUserId)ではない
+    //    - または、ステータスがすでにPENDINGではない
+    if (
+      !friendship ||
+      friendship.requesterUserId !== currentUserId ||
+      friendship.status !== 0
+    ) {
+      throw new ForbiddenException('この申請を操作する権限がありません。');
+    }
+
+    // 3. 権限があれば、ステータスを更新する
+    return this.prisma.friendship.update({
+      where: {
+        id: friendshipId,
+      },
+      data: {
+        status: newStatus,
+      },
+    });
   }
 }


### PR DESCRIPTION
## Why(背景)
Parent issue: #60
フレンド申請に対して、承認または拒否の操作を加える

## What(タスク)
  - **フレンド申請承認/拒否**
    - `PATCH /friends/requests/:friendshipI`
    - **機能**: 受信したフレンド申請を承認または拒否する。
    - **リクエストボディ**: `{ "status": "ACCEPTED" }` または `{ "status": "DECLINED" }`。
    - **処理**: `:friendshipId`で指定された`Friendship`レコードの`status`を更新する。操作は、申請された本人(`addresseeId`)しか行えないように権限チェックを行う。

## チェックリスト
- [x] フレンド申請承認/拒否(`PATCH /friends/requests/:friendshipId`)を実装する