### PR TITLE
fix: friendshipIdの絞り込み条件をandからorに修正 #65

### DIFF
--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -47,10 +47,10 @@ export class FriendshipService {
   async findReceivedRequests(userId: number) {
     const requestUser = await this.prisma.friendship.findMany({
       where: {
-        approvalUserId: userId,
-        approvalFriendStatus: {
-          name: 'PENDING',
-        },
+        OR: [
+          { approvalUserId: userId },
+          { approvalFriendStatus: { name: 'PENDING' } },
+        ],
       },
       include: {
         // requesterUserIdが参照するuserモデルにアクセスし、idとニックネームを結果に追加


### PR DESCRIPTION
## Why(背景)
- 複数人からフレンド申請が来ている状態で、
  １人の申請を承認/拒否した後にフレンド申請一覧取得を行うと結果が取れなくなる不具合が生じた。
  
## What(タスク)
- クエリの絞り込みの条件でORであるべき箇所がANDになっている可能性がないか調査する

## チェックリスト
- [x] findManyのWHERE句でOR演算子が使用されていること
- [x] friendship.service.ts修正後、フレンド申請に対してステータス：PENDING以外のステータスのレコードがある状態でも、ステータス:PENDING のみのレコードのみ抽出ができること