### PR TITLE
refactor: where句にundefiendが入らないように修正

### DIFF
--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -31,9 +31,13 @@ export class UserController {
 
   @UseGuards(AuthGuard)
   @Get('search')
-  async searchUsers(@Query('q') query: string, @Req() req: any) {
+  async searchUsers(
+    @Query('user_id') userId: string,
+    @Query('username') username: string,
+    @Req() req: any,
+  ) {
     const currentUserId = req.user.id;
-    return this.userService.searchUsersByQuery(query, currentUserId);
+    return this.userService.searchUsersByQuery(userId, username, currentUserId);
   }
 
   @Get(':id')

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,4 +1,8 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { PrismaService } from 'src/prisma.service';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -50,10 +54,26 @@ export class UserService {
     return selectUser;
   }
 
-  async searchUsersByQuery(query: string, currentUserId: number) {
-    if (!query) {
-      return []; // クエリが未指定の場合、検索は行わない(空配列を返す)
+  async searchUsersByQuery(
+    userId: string | undefined,
+    username: string | undefined,
+    currentUserId: number,
+  ) {
+    if (!userId && !username) {
+      throw new BadRequestException(
+        'ユーザーIDもしくはニックネームで検索してください。',
+      );
     }
+
+    let whereCondition: any = {};
+    if (userId) {
+      whereCondition.userId = userId;
+    }
+    if (username) {
+      whereCondition.username = username;
+    }
+
+    whereCondition.id = currentUserId;
 
     const users = await this.prisma.user.findMany({
       where: {
@@ -63,11 +83,11 @@ export class UserService {
             OR: [
               // OR条件その１: ユーザーIDがクエリと完全一致する
               {
-                userId: { equals: query },
+                userId: { equals: userId },
               },
               // OR条件その２: ニックネームがクエリを部分一致で含む(ただし、大文字小文字の区別なし)
               {
-                username: { contains: query, mode: 'insensitive' },
+                username: { contains: username, mode: 'insensitive' },
               },
             ],
           },

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -57,7 +57,7 @@ export class UserService {
   async searchUsersByQuery(
     userId: string | undefined,
     username: string | undefined,
-    currentUserId: number,
+    currentId: number,
   ) {
     if (!userId && !username) {
       throw new BadRequestException(
@@ -67,37 +67,24 @@ export class UserService {
 
     let whereCondition: any = {};
     if (userId) {
-      whereCondition.userId = userId;
+      whereCondition.userId = {
+        contains: userId,
+        mode: 'insensitive',
+      };
     }
     if (username) {
-      whereCondition.username = username;
+      whereCondition.username = {
+        contains: username,
+        mode: 'insensitive',
+      };
     }
 
-    whereCondition.id = currentUserId;
+    whereCondition.id = {
+      not: currentId,
+    };
 
     const users = await this.prisma.user.findMany({
-      where: {
-        AND: [
-          // AND条件その１: 以下のOR条件
-          {
-            OR: [
-              // OR条件その１: ユーザーIDがクエリと完全一致する
-              {
-                userId: { equals: userId },
-              },
-              // OR条件その２: ニックネームがクエリを部分一致で含む(ただし、大文字小文字の区別なし)
-              {
-                username: { contains: username, mode: 'insensitive' },
-              },
-            ],
-          },
-          // AND条件その２: ログインユーザーは検索結果から除外する
-          {
-            id: { not: currentUserId },
-          },
-        ],
-      },
-
+      where: whereCondition,
       select: {
         id: true,
         userId: true,


### PR DESCRIPTION
## Why(背景)
- #62 の修正
- クエリパラメータがどんな値をもらっているかが把握できない状態を改善する
- ユーザー検索APIのクエリの`where`句に`undefined`の値が入る場合があったため修正する

## What(タスク)
- コントローラで受け取る値ごとにクエリパラメータを追加
- 空の`whereCondition`を定義し、クエリパラメータによって`where`句の条件を追加

## チェックリスト
- [x] コントローラにクエリパラメータが２つ(`user_id`と`usrename`)追加されていること
- [x] サービスでwhere句で条件を決めた後にクエリ実行すること