### PR TITLE
feat: FriendshipRequestStatusをenumとして追加

### DIFF
--- a/backend/src/common/friendship-request-status.ts
+++ b/backend/src/common/friendship-request-status.ts
@@ -1,0 +1,7 @@
+enum FriendshipRequestStatus {
+  PENDING = 0,
+  ACCEPTED = 1,
+  DECLINED = 2,
+}
+
+export default FriendshipRequestStatus;

--- a/backend/src/common/requestStatus.ts
+++ b/backend/src/common/requestStatus.ts
@@ -1,7 +1,0 @@
-enum FriendshipRequestStatus {
-  PENDING = 0,
-  ACCEPTED = 1,
-  DECLINED = 2,
-}
-
-export default FriendshipRequestStatus;

--- a/backend/src/friendship/dto/update-friendship.dto.ts
+++ b/backend/src/friendship/dto/update-friendship.dto.ts
@@ -1,5 +1,5 @@
 import { IsInt, IsNotEmpty, IsIn } from 'class-validator';
-import FriendshipRequestStatus from 'src/common/FriendshipRequestStatus';
+import FriendshipRequestStatus from 'src/common/friendship-request-status';
 
 export class UpdateFriendshipDto {
   @IsInt()

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { CreateFriendshipDto } from './dto/create-friendship.dto';
 import { PrismaService } from 'src/prisma.service';
-import FriendshipRequestStatus from 'src/common/FriendshipRequestStatus';
+import FriendshipRequestStatus from 'src/common/friendship-request-status';
 
 @Injectable()
 export class FriendshipService {
@@ -46,10 +46,8 @@ export class FriendshipService {
   async findReceivedRequests(userId: number) {
     const requestUser = await this.prisma.friendship.findMany({
       where: {
-        OR: [
-          { approvalUserId: userId },
-          { status: FriendshipRequestStatus.PENDING },
-        ],
+        approvalUserId: userId,
+        status: FriendshipRequestStatus.PENDING,
       },
       include: {
         // requesterUserIdが参照するuserモデルにアクセスし、idとニックネームを結果に追加


### PR DESCRIPTION
## Why(背景)
- `status`に使用していたマジックナンバーを解消する

## What(タスク)
- `enum`として`FriendshipRequestStatus`を追加

## チェックリスト
- [x] ./backend/src/common 配下にFriendshipRequestStatus.tsを追加していること
- [x]  FriendshipRequestStatus.tsにenumで0,1,2に対応するステータスを定義していること
- [x] 既存のAPIでマジックナンバーを使用していた箇所がenumの定数に置き換わっていること 