### PR TITLE
feat: フレンド一覧取得API実装

### DIFF
--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -24,7 +24,7 @@ export class FriendshipController {
     return this.friendshipService.create(createFriendshipDto, req.user.id);
   }
 
-  @Get()
+  @Get('friends')
   async fiendFriendsAll(@Req() req: any) {
     return await this.friendshipService.fiendFriendsAll(req.user.id);
   }

--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -24,6 +24,11 @@ export class FriendshipController {
     return this.friendshipService.create(createFriendshipDto, req.user.id);
   }
 
+  @Get()
+  async fiendFriendsAll(@Req() req: any) {
+    return await this.friendshipService.fiendFriendsAll(req.user.id);
+  }
+
   @Get('requests/received')
   async findReceivedRequests(@Req() req: any) {
     return await this.friendshipService.findReceivedRequests(req.user.id);

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -43,6 +43,28 @@ export class FriendshipService {
     return friendRequest;
   }
 
+  async fiendFriendsAll(userId: number) {
+    const friendsList = await this.prisma.friendship.findMany({
+      where: {
+        approvalUserId: userId,
+        status: FriendshipRequestStatus.ACCEPTED,
+      },
+      include: {
+        // requesterUserIdが参照するuserモデルにアクセスし、idとニックネームを結果に追加
+        requester: {
+          select: {
+            id: true,
+            username: true,
+          },
+        },
+      },
+      orderBy: {
+        updateDate: 'desc',
+      },
+    });
+    return friendsList;
+  }
+
   async findReceivedRequests(userId: number) {
     const requestUser = await this.prisma.friendship.findMany({
       where: {


### PR DESCRIPTION
## Why(背景)

Parent issue: #60 
に必要なフレンド一覧取得APIを実装する


## What(タスク)
- **フレンド一覧取得**
    - `GET /friends`
    - **機能**: 自分のフレンド（`status`が`ACCEPTED`）を一覧で取得する。
    - **処理**: `Friendship`テーブルから、自分が`requesterId`または`addresseeId`に含まれ、かつ`status`が`ACCEPTED`のレコードを検索する。
    - **レスポンス**: 相手のユーザー情報だけを抽出した配列 `[{ id, username, userId }]`。

## チェックリスト
- [x] フレンド一覧取得(`GET /friendship/friends`)を実装
- [x] ログインユーザのフレンドのみが取得できること
- [x] usernameにアクセス可能なこと  