### PR TITLE
Feature/frontend/add friends list page

### DIFF
--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -26,7 +26,7 @@ export class FriendshipController {
 
   @Get('friends')
   async fiendFriendsAll(@Req() req: any) {
-    return await this.friendshipService.fiendFriendsAll(req.user.id);
+    return await this.friendshipService.findFriendsAll(req.user.id);
   }
 
   @Get('requests/received')

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -43,7 +43,7 @@ export class FriendshipService {
     return friendRequest;
   }
 
-  async fiendFriendsAll(userId: number) {
+  async findFriendsAll(userId: number) {
     const friendsList = await this.prisma.friendship.findMany({
       where: {
         approvalUserId: userId,

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -49,9 +49,10 @@ export class FriendshipService {
         approvalUserId: userId,
         status: FriendshipRequestStatus.ACCEPTED,
       },
-      include: {
-        // requesterUserIdが参照するuserモデルにアクセスし、idとニックネームを結果に追加
+      select: {
+        updateDate: true,
         requester: {
+          // requesterUserIdが参照するuserモデルにアクセスし、idとニックネームを結果に追加
           select: {
             id: true,
             username: true,
@@ -62,7 +63,10 @@ export class FriendshipService {
         updateDate: 'desc',
       },
     });
-    return friendsList;
+    const friends = friendsList.map((friendship) => {
+      return friendship.requester;
+    });
+    return friends;
   }
 
   async findReceivedRequests(userId: number) {

--- a/frontend/app/apiActions/Friendship.ts
+++ b/frontend/app/apiActions/Friendship.ts
@@ -1,0 +1,22 @@
+import { API_BASE_URL } from "~/config";
+import { getAuthHeaders } from "./apiHelper";
+
+// フレンド一覧取得処理呼び出し関数
+export const getFriendsList = async () => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/friendship/friends`, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+    if (response.status != 200) {
+      const errorData = await response.json();
+      throw new Error(
+        `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+      );
+    }
+    const result = await response.json();
+    return { success: true, data: result };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+};

--- a/frontend/app/components/common/Sidebar.tsx
+++ b/frontend/app/components/common/Sidebar.tsx
@@ -20,6 +20,10 @@ const Sidebar = () => {
   const navigateToExerciseCategoryManagerPage = () => {
     navigate("/exercise-category");
   };
+  // フレンド一覧画面に遷移
+  const navigateToFriendListPage = () => {
+    navigate("/friendship/my-friends-list");
+  };
   return (
     <aside className="sidebar">
       <div className="sidebar-content">
@@ -42,6 +46,9 @@ const Sidebar = () => {
           onClick={navigateToExerciseCategoryManagerPage}
           buttonName="種目管理"
         />
+      </div>
+      <div className="sidebar-content">
+        <Button onClick={navigateToFriendListPage} buttonName="フレンド一覧" />
       </div>
     </aside>
   );

--- a/frontend/app/pages/MyFriendsListPage.tsx
+++ b/frontend/app/pages/MyFriendsListPage.tsx
@@ -1,7 +1,25 @@
+import { useEffect, useState } from "react";
+import { getFriendsList } from "~/apiActions/Friendship";
+
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
+import type { Friend } from "~/type/friendship";
 
 const MyFriendsListPage = () => {
+  // フレンド一覧保持するuseState
+  const [friendsList, setFriendsList] = useState<Friend[]>([]);
+  // ページにアクセスした時点でフレンド一覧を読み込む
+  useEffect(() => {
+    (async () => {
+      const result = await getFriendsList();
+      if (result.success) {
+        setFriendsList(result.data);
+      } else {
+        alert(`一覧取得に失敗しました。\n\n${result.error}`);
+      }
+    })();
+  }, []);
+  console.log(friendsList);
   return (
     <div className="layout">
       <Header />
@@ -9,6 +27,24 @@ const MyFriendsListPage = () => {
         <Sidebar />
         <div className="content">
           <h1 className="page-title">フレンド一覧</h1>
+          {friendsList.length === 0 ? (
+            <div>
+              <p>まだフレンドはいません。</p>
+              <p>フレンド申請してみましょう！</p>
+            </div>
+          ) : (
+            <table>
+              <tbody>
+                {friendsList.map((friend) => {
+                  return (
+                    <tr key={friend.id}>
+                      <th className="friend-name-record">{friend.username}</th>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/app/pages/MyFriendsListPage.tsx
+++ b/frontend/app/pages/MyFriendsListPage.tsx
@@ -1,5 +1,18 @@
+import Header from "~/components/common/Header";
+import Sidebar from "~/components/common/Sidebar";
+
 const MyFriendsListPage = () => {
-  return <h1>MyFriendsListPage</h1>;
+  return (
+    <div className="layout">
+      <Header />
+      <div className="main-content">
+        <Sidebar />
+        <div className="content">
+          <h1 className="page-title">フレンド一覧</h1>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default MyFriendsListPage;

--- a/frontend/app/pages/MyFriendsListPage.tsx
+++ b/frontend/app/pages/MyFriendsListPage.tsx
@@ -1,0 +1,5 @@
+const MyFriendsListPage = () => {
+  return <h1>MyFriendsListPage</h1>;
+};
+
+export default MyFriendsListPage;

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -17,6 +17,7 @@ export default [
       route("create", "routes/TrainingRecordCreate.tsx"),
       route("update/:id", "routes/TrainingRecordEdit.tsx"),
       route("exercise-category", "routes/ExerciseCategoryManager.tsx"),
+      route("friendship/my-friends-list", "routes/MyFriendsList.tsx"),
     ]
   ),
 ] satisfies RouteConfig;

--- a/frontend/app/routes/MyFriendsList.tsx
+++ b/frontend/app/routes/MyFriendsList.tsx
@@ -1,0 +1,17 @@
+import Title from "~/utils/Title";
+import type { Route } from "../+types/root";
+import MyFriendsListPage from "~/pages/MyFriendsListPage";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    {
+      title: Title.title,
+      description: Title.description,
+      content: Title.content,
+    },
+  ];
+}
+
+export default function MyFriendsList() {
+  return <MyFriendsListPage />;
+}

--- a/frontend/app/type/friendship.ts
+++ b/frontend/app/type/friendship.ts
@@ -1,0 +1,4 @@
+export type Friend = {
+  id: number;
+  username: string;
+};


### PR DESCRIPTION
## Why(背景)
- Parent issue: #60
- アプリの画面上からフレンドを確認可能とする

## What(タスク)
 - フレンド関係にあるユーザーのニックネームの一覧を画面表示する。
 - サイドバーのボタンから画面遷移する。

## チェックリスト
- [x] フレンド関係にあるユーザーのニックネームが漏れなく表示されていること
- [x] フレンド関係にないユーザーのニックネームが表示されていないこと
- [x] サイドバーの「フレンド一覧」ボタンからフレンド一覧画面に遷移できること
- [x] フレンドがいない場合は、「フレンド申請してみましょう！」 と表示されること