### PR TITLE
feat(ui):ユーザー検索画面実装

### DIFF
--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   ParseIntPipe,
   Param,
+  Query,
 } from '@nestjs/common';
 import { FriendshipService } from './friendship.service';
 import { CreateFriendshipDto } from './dto/create-friendship.dto';
@@ -32,6 +33,18 @@ export class FriendshipController {
   @Get('requests/received')
   async findReceivedRequests(@Req() req: any) {
     return await this.friendshipService.findReceivedRequests(req.user.id);
+  }
+
+  @Get(':approvalUserId')
+  async findFriendshipStatus(
+    @Param('approvalUserId', ParseIntPipe) approvalUserId: number,
+    @Req() req: any,
+  ) {
+    const requesterUserId = req.user.id;
+    return await this.friendshipService.findFriendshipStatus(
+      approvalUserId,
+      requesterUserId,
+    );
   }
 
   @Patch(':friendshipId')

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -91,6 +91,26 @@ export class FriendshipService {
     return requestUser;
   }
 
+  async findFriendshipStatus(approvalUserId: number, requesterUserId: number) {
+    const friendship = await this.prisma.friendship.findFirst({
+      where: {
+        requesterUserId: requesterUserId,
+        approvalUserId: approvalUserId,
+      },
+      select: {
+        approvalFriendStatus: {
+          select: {
+            name: true,
+          },
+        },
+      },
+    });
+    if (!friendship) {
+      return null;
+    }
+    return friendship.approvalFriendStatus.name;
+  }
+
   async updateRequestStatus(
     friendshipId: number,
     newStatus: number,

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -31,13 +31,9 @@ export class UserController {
 
   @UseGuards(AuthGuard)
   @Get('search')
-  async searchUsers(
-    @Query('user_id') userId: string,
-    @Query('username') username: string,
-    @Req() req: any,
-  ) {
+  async searchUsers(@Query('user_id') userId: string, @Req() req: any) {
     const currentUserId = req.user.id;
-    return this.userService.searchUsersByQuery(userId, username, currentUserId);
+    return this.userService.searchUsersByQuery(userId, currentUserId);
   }
 
   @Get(':id')

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -59,7 +59,7 @@ export class UserService {
       throw new BadRequestException('検索するユーザーIDを入力してください。');
     }
 
-    const users = await this.prisma.user.findMany({
+    const user = await this.prisma.user.findFirst({
       where: {
         userId: { equals: userId },
         id: { not: currentId },
@@ -68,10 +68,39 @@ export class UserService {
         id: true,
         userId: true,
         username: true,
+
+        requesters: {
+          where: {
+            requesterUserId: currentId,
+          },
+          select: {
+            approvalFriendStatus: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
       },
     });
 
-    return users;
+    if (!user) {
+      return null;
+    }
+    // 取得したデータからステータスを取り出す
+    // receivedRequestsは配列なので、最初の要素を見る
+    const friendshipStatusName =
+      user.requesters[0]?.approvalFriendStatus?.name || null;
+
+    // 不要なリレーションデータを除外した、きれいなオブジェクトを返す
+    const result = {
+      id: user.id,
+      userId: user.userId,
+      username: user.username,
+      friendshipStatus: friendshipStatusName,
+    };
+
+    return result;
   }
 
   async findOne(id: number) {

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -68,35 +68,28 @@ export class UserService {
         id: true,
         userId: true,
         username: true,
-
-        requesters: {
-          where: {
-            requesterUserId: currentId,
-          },
-          select: {
-            approvalFriendStatus: {
-              select: {
-                name: true,
-              },
-            },
-          },
-        },
       },
     });
 
     if (!user) {
       return null;
     }
-    // 取得したデータからステータスを取り出す
-    // receivedRequestsは配列なので、最初の要素を見る
-    const friendshipStatusName =
-      user.requesters[0]?.approvalFriendStatus?.name || null;
+    const friendship = await this.prisma.friendship.findFirst({
+      where: {
+        requesterUserId: currentId,
+        approvalUserId: user.id,
+      },
+      include: {
+        approvalFriendStatus: { select: { name: true } },
+      },
+    });
 
-    // 不要なリレーションデータを除外した、きれいなオブジェクトを返す
+    // 3. データをマージして返す
+    const friendshipStatusName =
+      friendship?.approvalFriendStatus?.name || 'NONE';
+
     const result = {
-      id: user.id,
-      userId: user.userId,
-      username: user.username,
+      ...user,
       friendshipStatus: friendshipStatusName,
     };
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -54,37 +54,16 @@ export class UserService {
     return selectUser;
   }
 
-  async searchUsersByQuery(
-    userId: string | undefined,
-    username: string | undefined,
-    currentId: number,
-  ) {
-    if (!userId && !username) {
-      throw new BadRequestException(
-        'ユーザーIDもしくはニックネームで検索してください。',
-      );
+  async searchUsersByQuery(userId: string, currentId: number) {
+    if (!userId || userId.trim() === '') {
+      throw new BadRequestException('検索するユーザーIDを入力してください。');
     }
-
-    let whereCondition: any = {};
-    if (userId) {
-      whereCondition.userId = {
-        contains: userId,
-        mode: 'insensitive',
-      };
-    }
-    if (username) {
-      whereCondition.username = {
-        contains: username,
-        mode: 'insensitive',
-      };
-    }
-
-    whereCondition.id = {
-      not: currentId,
-    };
 
     const users = await this.prisma.user.findMany({
-      where: whereCondition,
+      where: {
+        userId: { equals: userId },
+        id: { not: currentId },
+      },
       select: {
         id: true,
         userId: true,

--- a/frontend/app/apiActions/Friendship.ts
+++ b/frontend/app/apiActions/Friendship.ts
@@ -43,3 +43,26 @@ export const createFriendRequest = async (params: {
     return { success: false, error: error.message };
   }
 };
+
+// フレンドシップ状態取得処理呼び出し関数
+export const getFriendshipStatus = async (approvalUserId: number) => {
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/friendship/${approvalUserId}`,
+      {
+        method: "GET",
+        headers: getAuthHeaders(),
+      }
+    );
+    if (response.status != 200) {
+      const errorData = await response.json();
+      throw new Error(
+        `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+      );
+    }
+    const result = await response.json();
+    return { success: true, data: result };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+};

--- a/frontend/app/apiActions/Friendship.ts
+++ b/frontend/app/apiActions/Friendship.ts
@@ -20,3 +20,26 @@ export const getFriendsList = async () => {
     return { success: false, error: error.message };
   }
 };
+
+// フレンド申請API呼び出し処理
+export const createFriendRequest = async (params: {
+  approvalUserId: number;
+}) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/friendship/requests`, {
+      method: "POST",
+      headers: getAuthHeaders(),
+      body: JSON.stringify(params),
+    });
+    if (response.status != 201) {
+      const errorData = await response.json();
+      throw new Error(
+        `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+      );
+    }
+    const result = await response.json();
+    return { success: true, data: result };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+};

--- a/frontend/app/apiActions/User.ts
+++ b/frontend/app/apiActions/User.ts
@@ -1,0 +1,42 @@
+import { API_BASE_URL } from "~/config";
+import { getAuthHeaders } from "./apiHelper";
+
+// 検索パラメータを受け取るための型を定義
+type SearchUserParams = {
+  userId?: string;
+};
+
+// ユーザー検索処理呼び出し関数
+export const getSearchedUsers = async (params: SearchUserParams) => {
+  // URLSearchParamsオブジェクトを作成
+  const query = new URLSearchParams();
+  console.log("初期値", query.toString());
+
+  // paramsに含まれる値だけをクエリに追加
+  if (params.userId) {
+    query.append("user_id", params.userId);
+  }
+  console.log("user_id", query.toString());
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/user/search${
+        query.toString() ? `?${query.toString()}` : ""
+      }`,
+      {
+        method: "GET",
+        headers: getAuthHeaders(),
+      }
+    );
+    if (response.status != 200) {
+      const errorData = await response.json();
+      throw new Error(
+        `HTTP ${errorData.statusCode} エラー\n${errorData.message}`
+      );
+    }
+    const result = await response.json();
+    return { success: true, data: result };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+};

--- a/frontend/app/components/InputForm.tsx
+++ b/frontend/app/components/InputForm.tsx
@@ -3,6 +3,7 @@ import Button from "./parts/Button";
 import ExerciseSelectionPulldown from "./parts/pulldown/ExerciseSelectionPulldown";
 import TargetSelectionPulldown from "./parts/pulldown/TargetSelectionPulldown";
 import type { PulldownSelectedValue } from "~/type/common";
+import { format } from "date-fns-tz";
 
 type Props = {
   exerciseOptions: PulldownSelectedValue[];
@@ -27,7 +28,7 @@ const InputForm = (props: Props) => {
     const newDate = new Date(newDateStr);
     props.setTrainingRecord({
       ...props.trainingRecord,
-      date: newDate,
+      date: format(newDate, "yyyy-MM-dd"),
     });
   };
 
@@ -97,7 +98,7 @@ const InputForm = (props: Props) => {
           <input
             type="date"
             name="date"
-            value={props.trainingRecord.date.toISOString().split("T")[0]}
+            value={props.trainingRecord.date.toString().split("T")[0]}
             onChange={handleDateChange}
           />
         </div>

--- a/frontend/app/components/common/Header.tsx
+++ b/frontend/app/components/common/Header.tsx
@@ -4,8 +4,10 @@ import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import TooltipIconButton from "../parts/TooltipIconButton";
 import { useNavigate } from "react-router";
 import SearchBox from "../parts/searchbox/Searchbox";
+import { useState } from "react";
 
 const Header = () => {
+  const [userKeyword, setUserKeyword] = useState<string>("");
   const navigate = useNavigate();
   // ログアウトするとログイン画面へ遷移
   const handleLogout = () => {
@@ -16,6 +18,18 @@ const Header = () => {
   const handleSingUp = () => {
     navigate("/sign-up");
   };
+
+  // ユーザー検索APIを呼び出す
+  const handleSearchUser = async (searchText: string) => {
+    // searchTextが空の場合は、APIを叩かずに結果を空にする
+    if (!searchText.trim()) {
+      setUserKeyword("");
+      return;
+    }
+    // ユーザー検索結果画面へ遷移
+    navigate(`/user/search?q=${encodeURIComponent(searchText)}`);
+  };
+
   const { user, logout, loading } = useAuth();
   if (loading) return null; // ローディング中は何も表示しない
   return (
@@ -62,7 +76,11 @@ const Header = () => {
         {user && (
           <>
             <div>
-              <SearchBox />
+              <SearchBox
+                userKeyword={userKeyword}
+                setUserKeyword={setUserKeyword}
+                handleSearchUser={handleSearchUser}
+              />
             </div>
             <div>
               <span>ログインユーザー：{user.username}</span>

--- a/frontend/app/components/common/Header.tsx
+++ b/frontend/app/components/common/Header.tsx
@@ -3,6 +3,7 @@ import LogoutIcon from "@mui/icons-material/Logout";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import TooltipIconButton from "../parts/TooltipIconButton";
 import { useNavigate } from "react-router";
+import SearchBox from "../parts/searchbox/Searchbox";
 
 const Header = () => {
   const navigate = useNavigate();
@@ -60,6 +61,9 @@ const Header = () => {
         {/* サインイン状態時にログインユーザーのニックネームとサインアウトボタンを表示 */}
         {user && (
           <>
+            <div>
+              <SearchBox />
+            </div>
             <div>
               <span>ログインユーザー：{user.username}</span>
             </div>

--- a/frontend/app/components/parts/searchbox/SearchBox.module.css
+++ b/frontend/app/components/parts/searchbox/SearchBox.module.css
@@ -1,0 +1,89 @@
+/* 親のラッパーを位置指定の基準点にする */
+.search_box_wrapper {
+  position: relative;
+  width: 300px; /* 例として幅を指定 */
+}
+
+/* 検索ボックス全体を、位置指定の基準点にする */
+.search_box {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: fit-content; /* 幅をコンテンツに合わせる */
+}
+
+.magnifying_glass {
+  display: inline-block;
+  position: absolute; /* ★ 絶対位置指定*/
+  top: 50%; /* 親要素の上から50%の位置 */
+  transform: translateY(-50%); /* 垂直方向中央揃え */
+  right: 1em;
+  width: 1em;
+  height: 1em;
+  color: inherit; /* ボタンのcolor(white)を継承 */
+  font-size: 16px;
+  z-index: 1; /* ★ アイコンを手前に持ってくる */
+  pointer-events: none; /* ★ アイコンがクリックを邪魔しないように */
+}
+.magnifying_glass::before {
+  content: ""; /* ★ 疑似要素を表示させるには必須 */
+  position: absolute; /* 親(span)を基準に絶対位置指定 */
+  top: 0px;
+  left: 0px;
+  width: 0.7em; /* 親の70%の幅 */
+  height: 0.7em; /* 親の70%の高さ */
+  border: 0.15em solid currentColor; /* 親と同じ色の線 */
+  border-radius: 50%; /* 正円にする */
+}
+.magnifying_glass::after {
+  content: ""; /* こちらも必須 */
+  position: absolute;
+  top: 9px;
+  left: 45%;
+  transform: rotate(-45deg); /* 45度回転させて斜めにする */
+  transform-origin: top left; /* 回転の軸を、要素の「左上」の角にする */
+  width: 0.15em; /* 細い棒 */
+  height: 0.5em; /* 親と同じ高さの棒 */
+  background-color: currentColor; /* 親と同じ色で塗りつぶす */
+}
+
+.search_input {
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  width: 100%; /* 親要素の幅いっぱいに広がる */
+  height: 40px;
+  padding: 8px 16px;
+  padding-right: 50px;
+  box-sizing: border-box;
+  outline: none;
+}
+
+/* input要素のplaceholderのスタイルを変更する */
+input::placeholder {
+  color: #aaa;
+  font-size: 14px; /* 文字サイズを14pxに */
+  font-style: italic; /* 文字をイタリック体（斜体）に */
+}
+
+/* 3. ボタンを絶対位置で、入力欄の右端に配置する */
+.search_button {
+  position: absolute;
+  top: 5;
+  right: 0;
+
+  /* ボタンのサイズと形 */
+  width: 45px; /* padding-rightより少し小さい値 */
+  height: 40px;
+  border: 1px solid #ccc;
+  border-radius: 0 20px 20px 0; /* 右側だけ角丸にする */
+
+  /* ★ ボタンの色を設定 */
+  background-color: #4a90e2;
+
+  cursor: pointer;
+  transition: background-color 0.2s; /* ホバー時の色の変化を滑らかに */
+}
+
+.search_button:hover {
+  background-color: #357abd; /* ホバー時の色 */
+}

--- a/frontend/app/components/parts/searchbox/Searchbox.tsx
+++ b/frontend/app/components/parts/searchbox/Searchbox.tsx
@@ -1,17 +1,26 @@
 import styles from "./SearchBox.module.css";
 
-const SearchBox = () => {
+type Props = {
+  userKeyword: string;
+  setUserKeyword: React.Dispatch<React.SetStateAction<string>>;
+  handleSearchUser: (searchText: string) => Promise<void>;
+};
+
+const SearchBox = (prop: Props) => {
   return (
     <div className={styles.search_box}>
       <input
         type="text"
         placeholder="ユーザーを検索"
         className={styles.search_input}
+        value={prop.userKeyword}
+        onChange={(e) => prop.setUserKeyword(e.target.value)}
       />
       <button
         type="button"
         className={styles.search_button}
         aria-label="検索"
+        onClick={() => prop.handleSearchUser(prop.userKeyword)}
       ></button>
       <span className={styles.magnifying_glass}></span>
     </div>

--- a/frontend/app/components/parts/searchbox/Searchbox.tsx
+++ b/frontend/app/components/parts/searchbox/Searchbox.tsx
@@ -11,7 +11,7 @@ const SearchBox = (prop: Props) => {
     <div className={styles.search_box}>
       <input
         type="text"
-        placeholder="ユーザーを検索"
+        placeholder="ユーザーIDで検索"
         className={styles.search_input}
         value={prop.userKeyword}
         onChange={(e) => prop.setUserKeyword(e.target.value)}

--- a/frontend/app/components/parts/searchbox/Searchbox.tsx
+++ b/frontend/app/components/parts/searchbox/Searchbox.tsx
@@ -1,0 +1,21 @@
+import styles from "./SearchBox.module.css";
+
+const SearchBox = () => {
+  return (
+    <div className={styles.search_box}>
+      <input
+        type="text"
+        placeholder="ユーザーを検索"
+        className={styles.search_input}
+      />
+      <button
+        type="button"
+        className={styles.search_button}
+        aria-label="検索"
+      ></button>
+      <span className={styles.magnifying_glass}></span>
+    </div>
+  );
+};
+
+export default SearchBox;

--- a/frontend/app/pages/UserSearchPage.tsx
+++ b/frontend/app/pages/UserSearchPage.tsx
@@ -6,6 +6,8 @@ import Sidebar from "~/components/common/Sidebar";
 import Box from "@mui/material/Box";
 import TooltipIconButton from "~/components/parts/TooltipIconButton";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import PendingActionsIcon from "@mui/icons-material/PendingActions";
+import VerifiedIcon from "@mui/icons-material/Verified";
 import type { UserWithFriendshipStatus } from "~/type/friendship";
 import { createFriendRequest } from "~/apiActions/Friendship";
 import AlertDialog from "~/components/common/AlertDialog";
@@ -25,15 +27,41 @@ const getStatusComponent = (
           iconButtonHoverBackgroundColor="white"
           iconButtonHoverColor="royalblue"
           id={userId}
-          onClick={() => callback(userId)}
+          onClick={() => {}}
           IconComponent={PersonAddIcon}
         />
       </Box>
     );
   } else if (friendshipStatus == "PENDING") {
-    return <p>申請中</p>;
+    return (
+      <Box display="flex" gap={0.5}>
+        <TooltipIconButton
+          tooltipTitle="申請中"
+          iconButtonBackgroundColor="sandybrown"
+          iconButtonColor="white"
+          iconButtonHoverBackgroundColor="white"
+          iconButtonHoverColor="sandybrown"
+          id={userId}
+          onClick={() => {}}
+          IconComponent={PendingActionsIcon}
+        />
+      </Box>
+    );
   } else if (friendshipStatus == "ACCEPTED") {
-    return <p>フレンド</p>;
+    return (
+      <Box display="flex" gap={0.5}>
+        <TooltipIconButton
+          tooltipTitle="フレンド"
+          iconButtonBackgroundColor="seagreen"
+          iconButtonColor="white"
+          iconButtonHoverBackgroundColor="white"
+          iconButtonHoverColor="seagreen"
+          id={userId}
+          onClick={() => {}}
+          IconComponent={VerifiedIcon}
+        />
+      </Box>
+    );
   }
 };
 

--- a/frontend/app/pages/UserSearchPage.tsx
+++ b/frontend/app/pages/UserSearchPage.tsx
@@ -11,11 +11,11 @@ import { createFriendRequest } from "~/apiActions/Friendship";
 import AlertDialog from "~/components/common/AlertDialog";
 
 const getStatusComponent = (
-  friendshipStatus: string | null,
+  friendshipStatus: string,
   userId: number,
   callback: (addresseeId: number) => Promise<void>
 ) => {
-  if (friendshipStatus == null) {
+  if (friendshipStatus == "NONE") {
     return (
       <Box display="flex" gap={0.5}>
         <TooltipIconButton
@@ -38,10 +38,18 @@ const getStatusComponent = (
 };
 
 const UserSearchPage = () => {
+  const dummyUser = {
+    id: 0,
+    username: "dummy-user",
+    friendshipStatus: "NONE",
+  };
   // フレンド一覧保持するuseState
-  const [foundUser, setFoundUser] = useState<UserWithFriendshipStatus | null>(
-    null
-  );
+  const [foundUser, setFoundUser] = useState<UserWithFriendshipStatus>({
+    id: 0,
+    username: "dummy-user",
+    friendshipStatus: "NONE",
+  });
+  console.log("foundUser0", foundUser);
   const [loading, setLoading] = useState(true);
   // ダイアログの状態を管理
   const [dialog, setDialog] = useState({
@@ -90,7 +98,8 @@ const UserSearchPage = () => {
           userId: query,
         });
         if (result.success) {
-          const userObject = result.data[0];
+          const userObject = result.data;
+          console.log("userObject", userObject);
           setFoundUser(userObject);
           console.log("foundUser1", foundUser);
         } else {
@@ -102,7 +111,6 @@ const UserSearchPage = () => {
       fetchUsers();
     } else {
       // クエリがない場合は、何も表示しない
-      setFoundUser(null);
       setLoading(false);
     }
     // ★ searchParamsが変更されるたびに、このeffectを再実行する
@@ -118,7 +126,7 @@ const UserSearchPage = () => {
         <Sidebar />
         <div className="content">
           <h1 className="page-title">ユーザー検索結果</h1>
-          {foundUser == null ? (
+          {foundUser == dummyUser ? (
             <div>
               <p>検索条件に一致するユーザーがいませんでした。</p>
             </div>

--- a/frontend/app/pages/UserSearchPage.tsx
+++ b/frontend/app/pages/UserSearchPage.tsx
@@ -6,13 +6,42 @@ import Sidebar from "~/components/common/Sidebar";
 import Box from "@mui/material/Box";
 import TooltipIconButton from "~/components/parts/TooltipIconButton";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
-import type { Users } from "~/type/friendship";
+import type { UserWithFriendshipStatus } from "~/type/friendship";
 import { createFriendRequest } from "~/apiActions/Friendship";
 import AlertDialog from "~/components/common/AlertDialog";
 
+const getStatusComponent = (
+  friendshipStatus: number | null,
+  userId: number,
+  callback: (addresseeId: number) => Promise<void>
+) => {
+  if (friendshipStatus == null) {
+    return (
+      <Box display="flex" gap={0.5}>
+        <TooltipIconButton
+          tooltipTitle="フレンド申請"
+          iconButtonBackgroundColor="royalblue"
+          iconButtonColor="white"
+          iconButtonHoverBackgroundColor="white"
+          iconButtonHoverColor="royalblue"
+          id={userId}
+          onClick={() => callback(userId)}
+          IconComponent={PersonAddIcon}
+        />
+      </Box>
+    );
+  } else if (friendshipStatus == 0) {
+    return <p>申請中</p>;
+  } else if (friendshipStatus == 1) {
+    return <p>フレンド</p>;
+  }
+};
+
 const UserSearchPage = () => {
   // フレンド一覧保持するuseState
-  const [usersList, setUsersList] = useState<Users[]>([]);
+  const [foundUser, setFoundUser] = useState<UserWithFriendshipStatus | null>(
+    null
+  );
   const [loading, setLoading] = useState(true);
   // ダイアログの状態を管理
   const [dialog, setDialog] = useState({
@@ -33,9 +62,8 @@ const UserSearchPage = () => {
       setDialog({
         open: true,
         title: "成功",
-        message: `ユーザーID: ${usersList.map((user) => {
-          return user.username;
-        })} にフレンド申請を送りました。`,
+        message: `ユーザーID:
+        にフレンド申請を送りました。`,
       });
     } else {
       // エラーダイアログを表示するstateを更新
@@ -62,7 +90,8 @@ const UserSearchPage = () => {
           userId: query,
         });
         if (result.success) {
-          setUsersList(result.data);
+          const userObject = result.data[0];
+          setFoundUser(userObject);
         } else {
           console.error(result.error);
           alert("検索結果の取得に失敗しました。");
@@ -72,7 +101,7 @@ const UserSearchPage = () => {
       fetchUsers();
     } else {
       // クエリがない場合は、何も表示しない
-      setUsersList([]);
+      setFoundUser(null);
       setLoading(false);
     }
     // ★ searchParamsが変更されるたびに、このeffectを再実行する
@@ -87,7 +116,7 @@ const UserSearchPage = () => {
         <Sidebar />
         <div className="content">
           <h1 className="page-title">ユーザー検索結果</h1>
-          {usersList.length === 0 ? (
+          {foundUser == null ? (
             <div>
               <p>検索条件に一致するユーザーがいませんでした。</p>
             </div>
@@ -95,27 +124,16 @@ const UserSearchPage = () => {
             <div className="table-container">
               <table>
                 <tbody>
-                  {usersList.map((user) => {
-                    return (
-                      <tr key={user.id}>
-                        <th className="user-name-record">{user.username}</th>
-                        <th className="user-name-record">
-                          <Box display="flex" gap={0.5}>
-                            <TooltipIconButton
-                              tooltipTitle="フレンド申請"
-                              iconButtonBackgroundColor="royalblue"
-                              iconButtonColor="white"
-                              iconButtonHoverBackgroundColor="white"
-                              iconButtonHoverColor="royalblue"
-                              id={user.id}
-                              onClick={() => handlerFriendRequest(user.id)}
-                              IconComponent={PersonAddIcon}
-                            />
-                          </Box>
-                        </th>
-                      </tr>
-                    );
-                  })}
+                  <tr key={foundUser.id}>
+                    <th className="user-name-record">{foundUser.username}</th>
+                    <th className="user-name-record">
+                      {getStatusComponent(
+                        null,
+                        foundUser.id,
+                        handlerFriendRequest
+                      )}
+                    </th>
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/frontend/app/pages/UserSearchPage.tsx
+++ b/frontend/app/pages/UserSearchPage.tsx
@@ -27,7 +27,7 @@ const getStatusComponent = (
           iconButtonHoverBackgroundColor="white"
           iconButtonHoverColor="royalblue"
           id={userId}
-          onClick={() => {}}
+          onClick={() => callback(userId)}
           IconComponent={PersonAddIcon}
         />
       </Box>
@@ -68,16 +68,17 @@ const getStatusComponent = (
 const UserSearchPage = () => {
   const dummyUser = {
     id: 0,
+    userId: "xxxxxxxx",
     username: "dummy-user",
     friendshipStatus: "NONE",
   };
   // フレンド一覧保持するuseState
   const [foundUser, setFoundUser] = useState<UserWithFriendshipStatus>({
     id: 0,
+    userId: "xxxxxxxx",
     username: "dummy-user",
     friendshipStatus: "NONE",
   });
-  console.log("foundUser0", foundUser);
   const [loading, setLoading] = useState(true);
   // ダイアログの状態を管理
   const [dialog, setDialog] = useState({
@@ -118,7 +119,6 @@ const UserSearchPage = () => {
     // ★ URLからクエリパラメータ 'q' の値を取得
     const query = searchParams.get("q");
     // クエリが存在する場合のみAPIを呼び出す
-    console.log(query);
     if (query) {
       const fetchUsers = async () => {
         setLoading(true);
@@ -127,9 +127,7 @@ const UserSearchPage = () => {
         });
         if (result.success) {
           const userObject = result.data;
-          console.log("userObject", userObject);
           setFoundUser(userObject);
-          console.log("foundUser1", foundUser);
         } else {
           console.error(result.error);
           alert("検索結果の取得に失敗しました。");
@@ -143,7 +141,6 @@ const UserSearchPage = () => {
     }
     // ★ searchParamsが変更されるたびに、このeffectを再実行する
   }, [searchParams]);
-  console.log("foundUser2", foundUser);
   if (loading) {
     return <div>Loading...</div>; // ローディング表示
   }

--- a/frontend/app/pages/UserSearchPage.tsx
+++ b/frontend/app/pages/UserSearchPage.tsx
@@ -11,7 +11,7 @@ import { createFriendRequest } from "~/apiActions/Friendship";
 import AlertDialog from "~/components/common/AlertDialog";
 
 const getStatusComponent = (
-  friendshipStatus: number | null,
+  friendshipStatus: string | null,
   userId: number,
   callback: (addresseeId: number) => Promise<void>
 ) => {
@@ -30,9 +30,9 @@ const getStatusComponent = (
         />
       </Box>
     );
-  } else if (friendshipStatus == 0) {
+  } else if (friendshipStatus == "PENDING") {
     return <p>申請中</p>;
-  } else if (friendshipStatus == 1) {
+  } else if (friendshipStatus == "ACCEPTED") {
     return <p>フレンド</p>;
   }
 };
@@ -92,6 +92,7 @@ const UserSearchPage = () => {
         if (result.success) {
           const userObject = result.data[0];
           setFoundUser(userObject);
+          console.log("foundUser1", foundUser);
         } else {
           console.error(result.error);
           alert("検索結果の取得に失敗しました。");
@@ -106,6 +107,7 @@ const UserSearchPage = () => {
     }
     // ★ searchParamsが変更されるたびに、このeffectを再実行する
   }, [searchParams]);
+  console.log("foundUser2", foundUser);
   if (loading) {
     return <div>Loading...</div>; // ローディング表示
   }
@@ -128,7 +130,7 @@ const UserSearchPage = () => {
                     <th className="user-name-record">{foundUser.username}</th>
                     <th className="user-name-record">
                       {getStatusComponent(
-                        null,
+                        foundUser.friendshipStatus,
                         foundUser.id,
                         handlerFriendRequest
                       )}

--- a/frontend/app/pages/UserSearchPage.tsx
+++ b/frontend/app/pages/UserSearchPage.tsx
@@ -1,0 +1,4 @@
+const UserSearchPage = () => {
+  return <p>ユーザー検索画面</p>;
+};
+export default UserSearchPage;

--- a/frontend/app/pages/UserSearchPage.tsx
+++ b/frontend/app/pages/UserSearchPage.tsx
@@ -3,15 +3,52 @@ import { useSearchParams } from "react-router";
 import { getSearchedUsers } from "~/apiActions/User";
 import Header from "~/components/common/Header";
 import Sidebar from "~/components/common/Sidebar";
+import Box from "@mui/material/Box";
+import TooltipIconButton from "~/components/parts/TooltipIconButton";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import type { Users } from "~/type/friendship";
+import { createFriendRequest } from "~/apiActions/Friendship";
+import AlertDialog from "~/components/common/AlertDialog";
 
 const UserSearchPage = () => {
   // フレンド一覧保持するuseState
   const [usersList, setUsersList] = useState<Users[]>([]);
   const [loading, setLoading] = useState(true);
+  // ダイアログの状態を管理
+  const [dialog, setDialog] = useState({
+    open: false,
+    title: "",
+    message: "",
+  });
 
-  // ★ URLのクエリパラメータを取得するためのフック
+  // URLのクエリパラメータを取得するためのフック
   const [searchParams] = useSearchParams();
+
+  // フレンド申請API呼び出しハンドラー
+  const handlerFriendRequest = async (addresseeId: number) => {
+    const result = await createFriendRequest({ approvalUserId: addresseeId });
+
+    if (result.success) {
+      // 成功ダイアログを表示するstateを更新
+      setDialog({
+        open: true,
+        title: "成功",
+        message: `ユーザーID: ${usersList.map((user) => {
+          return user.username;
+        })} にフレンド申請を送りました。`,
+      });
+    } else {
+      // エラーダイアログを表示するstateを更新
+      setDialog({
+        open: true,
+        title: "エラー",
+        message: `フレンド申請に失敗しました。\n\n${result.error}`,
+      });
+    }
+  };
+  const handleCloseDialog = async () => {
+    setDialog({ ...dialog, open: false });
+  };
   // ページにアクセスした時点でフレンド一覧を読み込む
   useEffect(() => {
     // ★ URLからクエリパラメータ 'q' の値を取得
@@ -62,6 +99,20 @@ const UserSearchPage = () => {
                     return (
                       <tr key={user.id}>
                         <th className="user-name-record">{user.username}</th>
+                        <th className="user-name-record">
+                          <Box display="flex" gap={0.5}>
+                            <TooltipIconButton
+                              tooltipTitle="フレンド申請"
+                              iconButtonBackgroundColor="royalblue"
+                              iconButtonColor="white"
+                              iconButtonHoverBackgroundColor="white"
+                              iconButtonHoverColor="royalblue"
+                              id={user.id}
+                              onClick={() => handlerFriendRequest(user.id)}
+                              IconComponent={PersonAddIcon}
+                            />
+                          </Box>
+                        </th>
                       </tr>
                     );
                   })}
@@ -70,6 +121,7 @@ const UserSearchPage = () => {
             </div>
           )}
         </div>
+        <AlertDialog dialog={dialog} handleCloseDialog={handleCloseDialog} />
       </div>
     </div>
   );

--- a/frontend/app/pages/UserSearchPage.tsx
+++ b/frontend/app/pages/UserSearchPage.tsx
@@ -1,4 +1,77 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
+import { getSearchedUsers } from "~/apiActions/User";
+import Header from "~/components/common/Header";
+import Sidebar from "~/components/common/Sidebar";
+import type { Users } from "~/type/friendship";
+
 const UserSearchPage = () => {
-  return <p>ユーザー検索画面</p>;
+  // フレンド一覧保持するuseState
+  const [usersList, setUsersList] = useState<Users[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // ★ URLのクエリパラメータを取得するためのフック
+  const [searchParams] = useSearchParams();
+  // ページにアクセスした時点でフレンド一覧を読み込む
+  useEffect(() => {
+    // ★ URLからクエリパラメータ 'q' の値を取得
+    const query = searchParams.get("q");
+    // クエリが存在する場合のみAPIを呼び出す
+    console.log(query);
+    if (query) {
+      const fetchUsers = async () => {
+        setLoading(true);
+        const result = await getSearchedUsers({
+          userId: query,
+        });
+        if (result.success) {
+          setUsersList(result.data);
+        } else {
+          console.error(result.error);
+          alert("検索結果の取得に失敗しました。");
+        }
+        setLoading(false);
+      };
+      fetchUsers();
+    } else {
+      // クエリがない場合は、何も表示しない
+      setUsersList([]);
+      setLoading(false);
+    }
+    // ★ searchParamsが変更されるたびに、このeffectを再実行する
+  }, [searchParams]);
+  if (loading) {
+    return <div>Loading...</div>; // ローディング表示
+  }
+  return (
+    <div className="layout">
+      <Header />
+      <div className="main-content">
+        <Sidebar />
+        <div className="content">
+          <h1 className="page-title">ユーザー検索結果</h1>
+          {usersList.length === 0 ? (
+            <div>
+              <p>検索条件に一致するユーザーがいませんでした。</p>
+            </div>
+          ) : (
+            <div className="table-container">
+              <table>
+                <tbody>
+                  {usersList.map((user) => {
+                    return (
+                      <tr key={user.id}>
+                        <th className="user-name-record">{user.username}</th>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 };
 export default UserSearchPage;

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -18,6 +18,7 @@ export default [
       route("update/:id", "routes/TrainingRecordEdit.tsx"),
       route("exercise-category", "routes/ExerciseCategoryManager.tsx"),
       route("friendship/my-friends-list", "routes/MyFriendsList.tsx"),
+      route("user/search", "routes/UserSearch.tsx"),
     ]
   ),
 ] satisfies RouteConfig;

--- a/frontend/app/routes/UserSearch.tsx
+++ b/frontend/app/routes/UserSearch.tsx
@@ -1,0 +1,17 @@
+import Title from "~/utils/Title";
+import type { Route } from "../+types/root";
+import UserSearchPage from "~/pages/UserSearchPage";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    {
+      title: Title.title,
+      description: Title.description,
+      content: Title.content,
+    },
+  ];
+}
+
+export default function UserSearch() {
+  return <UserSearchPage />;
+}

--- a/frontend/app/type/friendship.ts
+++ b/frontend/app/type/friendship.ts
@@ -1,4 +1,4 @@
-export type Users = {
+export type User = {
   id: number;
   username: string;
 };
@@ -6,4 +6,10 @@ export type Users = {
 export type Friend = {
   id: number;
   username: string;
+};
+
+export type FriendshipStatus = "PENDING" | "ACCEPTED" | null;
+
+export type UserWithFriendshipStatus = User & {
+  friendshipStatus: FriendshipStatus;
 };

--- a/frontend/app/type/friendship.ts
+++ b/frontend/app/type/friendship.ts
@@ -8,7 +8,7 @@ export type Friend = {
   username: string;
 };
 
-export type FriendshipStatus = "PENDING" | "ACCEPTED" | null;
+export type FriendshipStatus = "PENDING" | "ACCEPTED" | "NONE";
 
 export type UserWithFriendshipStatus = User & {
   friendshipStatus: FriendshipStatus;

--- a/frontend/app/type/friendship.ts
+++ b/frontend/app/type/friendship.ts
@@ -1,3 +1,8 @@
+export type Users = {
+  id: number;
+  username: string;
+};
+
 export type Friend = {
   id: number;
   username: string;

--- a/frontend/app/type/friendship.ts
+++ b/frontend/app/type/friendship.ts
@@ -1,5 +1,6 @@
 export type User = {
   id: number;
+  userId: string;
   username: string;
 };
 


### PR DESCRIPTION
## Why（背景）
Parent issue: #60
のうち、ユーザー検索画面を実装する

## What（タスク）
- ニックネームによるユーザーの**部分一致・大文字小文字無視**検索機能を提供する。
- 検索結果には、**自分自身は表示しない**。
- 検索結果が0件の場合は、「ユーザーが見つかりませんでした」といったメッセージを表示する。
- 検索結果の各ユーザーについて、ログインユーザーとの現在の関係性を表示し、それに応じたアクションボタンを提供する。
  - **他人**: 「フレンド申請」ボタンを表示する。
  - **申請済み（自分が申請した）**: 「申請中」というテキスト（または無効化されたボタン）を表示する。
  - **被申請中（相手から申請が来ている）**: 「承認」「拒否」ボタンを表示する。
  - **フレンド**: 「フレンド」というテキスト（または無効化されたボタン）を表示する。

## チェックリスト
- [x] `UserSearchPage.tsx`コンポーネントを作成し、ルーティング (`routes.ts`) を設定する。
- [x] 検索キーワードを管理するための`useState`を実装する。
- [x] 検索APIの呼び出しと、結果（ユーザーリスト）を管理するためのロジックを実装する。
- [x] ユーザーとの関係性（APIから受け取ったステータス）に応じて、表示するボタンを切り替える`FriendActionButton`のような子コンポーネントを作成する。
- [x] 各アクションボタン（申請、承認など）がクリックされたときに、対応するAPIを呼び出す処理を実装する。