### PR TITLE
ヘッダーにフレンド承認画面遷移用のリンクを追加

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -230,6 +230,19 @@ input::placeholder {
   font-size: 9px;
 }
 
+.username-link {
+  color: white;
+  text-decoration: none;
+  font-weight: normal;
+  transition: color 0.2s ease-in-out; /* 色の変化を滑らかにする */
+}
+
+.username-link:hover {
+  /* ホバー時に、少しだけ明るい色（ライトグレー）にする */
+  color: #d1d5db; /* Tailwind CSSの gray-300 に近い色 */
+  text-decoration: none; /* ホバー時も下線は出さない */
+}
+
 /* ==========================================================================
    Responsive Design (for screens 768px or less)
    ========================================================================== */

--- a/frontend/app/components/common/Header.tsx
+++ b/frontend/app/components/common/Header.tsx
@@ -5,6 +5,7 @@ import TooltipIconButton from "../parts/TooltipIconButton";
 import { useNavigate } from "react-router";
 import SearchBox from "../parts/searchbox/Searchbox";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 const Header = () => {
   const [userKeyword, setUserKeyword] = useState<string>("");
@@ -83,7 +84,10 @@ const Header = () => {
               />
             </div>
             <div>
-              <span>ログインユーザー：{user.username}</span>
+              <span>ログインユーザー：</span>
+              <Link to={`/friendship/accepted`} className="username-link">
+                {user.username}
+              </Link>
             </div>
             <div>
               <TooltipIconButton

--- a/frontend/app/pages/FriendshipAcceptedPage.tsx
+++ b/frontend/app/pages/FriendshipAcceptedPage.tsx
@@ -109,7 +109,7 @@ const FriendshipAcceptedPage = () => {
           <h1 className="page-title">フレンド承認画面</h1>
           {requestUsers.length === 0 ? (
             <div>
-              <p>検索条件に一致するユーザーがいませんでした。</p>
+              <p>現在フレンド申請は０件です。。</p>
             </div>
           ) : (
             <div className="table-container">

--- a/frontend/app/pages/FriendshipAcceptedPage.tsx
+++ b/frontend/app/pages/FriendshipAcceptedPage.tsx
@@ -109,7 +109,7 @@ const FriendshipAcceptedPage = () => {
           <h1 className="page-title">フレンド承認画面</h1>
           {requestUsers.length === 0 ? (
             <div>
-              <p>現在フレンド申請は０件です。。</p>
+              <p>現在フレンド申請は０件です。</p>
             </div>
           ) : (
             <div className="table-container">


### PR DESCRIPTION
Close #99

# Why（背景）
- 画面から#99で作成したフレンド承認画面へ遷移を可能とする

# What（タスク）
- ヘッダーのユーザーネームにリンクを追加する

# チェックリスト
- [x] ユーザーネームにフレンド承認画面へのリンクが設定されていること
- [x] ユーザーネームをホバーするとスタイルが変更されること 